### PR TITLE
Use environment variables only in the vars field

### DIFF
--- a/examples/rest.yml
+++ b/examples/rest.yml
@@ -1,11 +1,14 @@
 name: REST API Example
+env:
+  token: {TOKEN}
+  url: {URL ?? 'https://httpbin.org'}
 jobs:
-- name: Request to httpbin.org
+- name: Request to {env.url}
   defaults:
     http:
-      url: https://httpbin.org
+      url: {env.url}
       headers:
-        authorization: Bearer {env.TOKEN}
+        authorization: Bearer {env.token}
         content-type: application/json
         accept: application/json
   steps:

--- a/examples/rest.yml
+++ b/examples/rest.yml
@@ -1,14 +1,14 @@
 name: REST API Example
-env:
-  token: {TOKEN}
-  url: {URL ?? 'https://httpbin.org'}
+vars:
+  token: "{TOKEN ?? 'secret'}"
+  url: "{URL ?? 'https://httpbin.org'}"
 jobs:
-- name: Request to {env.url}
+- name: "Request to {vars.url}"
   defaults:
     http:
-      url: {env.url}
+      url: "{vars.url}"
       headers:
-        authorization: Bearer {env.token}
+        authorization: "Bearer {vars.token}"
         content-type: application/json
         accept: application/json
   steps:

--- a/expr.go
+++ b/expr.go
@@ -65,6 +65,14 @@ func (e *Expr) EvalTemplateStr(s string, env any) (string, error) {
 	return fmt.Sprintf("%s%v%s", s[:start], output, s[end+1:]), nil
 }
 
+func (e *Expr) Eval(s string, env any) (string, error) {
+	if strings.Contains(s, e.start) && strings.Contains(s, e.end) {
+		return e.EvalTemplateStr(s, env)
+	}
+	output, err := EvalExpr(s, env)
+	return fmt.Sprintf("%v", output), err
+}
+
 func EvalExpr(input string, env any) (any, error) {
 	return ex.Eval(input, env)
 }

--- a/expr_test.go
+++ b/expr_test.go
@@ -1,0 +1,89 @@
+package probe
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewExpr(t *testing.T) {
+	expected := &Expr{
+		start: "{",
+		end:   "}",
+	}
+	actual := NewExpr()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Structs are not equal: expected %+v, got %+v", expected, actual)
+	}
+}
+
+func TestEvalTemplate(t *testing.T) {
+	exprs := map[string]any{
+		"url":           "{env.URL}",
+		"authorization": "Bearer {env.TOKEN}",
+	}
+	env := map[string]any{
+		"env": map[string]any{
+			"URL":   "https://example.com",
+			"TOKEN": "secrets",
+		},
+	}
+	expected := map[string]any{
+		"url":           "https://example.com",
+		"authorization": "Bearer secrets",
+	}
+	actual := NewExpr().EvalTemplate(exprs, env)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("map are not equal: expected %+v, got %+v", expected, actual)
+	}
+}
+
+func TestEvalTemplateStr(t *testing.T) {
+	tests := []struct {
+		name     string
+		str      string
+		env      map[string]any
+		expected string
+	}{
+		{
+			name: "only variable",
+			str:  "{env.URL}",
+			env: map[string]any{
+				"env": map[string]any{
+					"URL": "https://example.com",
+				},
+			},
+			expected: "https://example.com",
+		},
+		{
+			name: "use nil coalescing operator",
+			str:  "{env.URL ?? 'http://localhost'}",
+			env: map[string]any{
+				"env": map[string]any{},
+			},
+			expected: "http://localhost",
+		},
+		{
+			name: "use ternary operator",
+			str:  "{env.URL == 'localhost' ? 'http://localhost:3000' : env.URL}",
+			env: map[string]any{
+				"env": map[string]any{
+					"URL": "localhost",
+				},
+			},
+			expected: "http://localhost:3000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := NewExpr()
+			actual, err := expr.EvalTemplateStr(tt.str, tt.env)
+			if err != nil {
+				t.Errorf("EvalTemplateStr error %s", err)
+			}
+			if tt.expected != actual {
+				t.Errorf("expected %+v, got %+v", tt.expected, actual)
+			}
+		})
+	}
+}

--- a/probe.go
+++ b/probe.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/goccy/go-yaml"
@@ -37,9 +36,7 @@ func (p *Probe) Do() error {
 		return err
 	}
 
-	p.workflow.Start(p.config)
-
-	return nil
+	return p.workflow.Start(p.config)
 }
 
 func (p *Probe) ExitStatus() int {
@@ -106,17 +103,4 @@ func (p *Probe) setDefaults(data, defaults map[string]any) {
 			}
 		}
 	}
-}
-
-func getEnvMap() map[string]string {
-	envmap := make(map[string]string)
-
-	for _, env := range os.Environ() {
-		parts := strings.SplitN(env, "=", 2)
-		if len(parts) == 2 {
-			envmap[parts[0]] = parts[1]
-		}
-	}
-
-	return envmap
 }

--- a/reflect.go
+++ b/reflect.go
@@ -306,3 +306,11 @@ func TitleCase(st string, char string) string {
 	}
 	return strings.Join(parts, char)
 }
+
+func StrmapToAnymap(strmap map[string]string) map[string]any {
+	anymap := make(map[string]any)
+	for k, v := range strmap {
+		anymap[k] = v
+	}
+	return anymap
+}

--- a/reflect.go
+++ b/reflect.go
@@ -3,6 +3,7 @@ package probe
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -313,4 +314,15 @@ func StrmapToAnymap(strmap map[string]string) map[string]any {
 		anymap[k] = v
 	}
 	return anymap
+}
+
+func EnvMap() map[string]string {
+	env := make(map[string]string)
+	for _, v := range os.Environ() {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) == 2 {
+			env[parts[0]] = parts[1]
+		}
+	}
+	return env
 }

--- a/testdata/marshaled-workflow.yml
+++ b/testdata/marshaled-workflow.yml
@@ -57,3 +57,5 @@ jobs:
     count: 60
     interval: 10
   defaults: null
+vars:
+  host: http://localhost

--- a/testdata/workflow.yml
+++ b/testdata/workflow.yml
@@ -1,4 +1,6 @@
 name: Send queue congestion experiment
+vars:
+  host: http://localhost
 jobs:
 - name: Normal sender
   repeat:

--- a/workflow.go
+++ b/workflow.go
@@ -2,6 +2,7 @@ package probe
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -9,9 +10,11 @@ import (
 )
 
 type Workflow struct {
-	Name       string `yaml:"name",validate:"required"`
-	Jobs       []Job  `yaml:"jobs",validate:"required"`
+	Name       string            `yaml:"name",validate:"required"`
+	Jobs       []Job             `yaml:"jobs",validate:"required"`
+	Vars       map[string]string `yaml:"vars"`
 	exitStatus int
+	env        map[string]string
 }
 
 func (w *Workflow) SetExitStatus(isErr bool) {
@@ -20,8 +23,13 @@ func (w *Workflow) SetExitStatus(isErr bool) {
 	}
 }
 
-func (w *Workflow) Start(c Config) {
-	ctx := w.createContext(c)
+func (w *Workflow) Start(c Config) error {
+	vars, err := w.evalVars()
+	if err != nil {
+		return err
+	}
+
+	ctx := w.newContext(c, vars)
 	var wg sync.WaitGroup
 
 	for _, job := range w.Jobs {
@@ -47,18 +55,56 @@ func (w *Workflow) Start(c Config) {
 	}
 
 	wg.Wait()
+
+	return nil
 }
 
-func (w *Workflow) createContext(c Config) JobContext {
+func (w *Workflow) Env() map[string]string {
+	if len(w.env) == 0 {
+		w.env = EnvMap()
+	}
+	return w.env
+}
+
+func (w *Workflow) evalVars() (map[string]string, error) {
+	env := StrmapToAnymap(w.Env())
+	vars := make(map[string]string)
+
+	expr := NewExpr()
+	for k, v := range w.Vars {
+		var output string
+		output, err := expr.Eval(v, env)
+		if err != nil {
+			return vars, err
+		}
+		vars[k] = output
+	}
+
+	nilenv := []string{}
+	for k, v := range vars {
+		if strings.Contains(v, "<nil>") {
+			name := strings.Trim(w.Vars[k], expr.start+expr.end)
+			nilenv = append(nilenv, name)
+		}
+	}
+
+	if len(nilenv) > 0 {
+		return nil, fmt.Errorf("environment(%s) is nil", strings.Join(nilenv, ","))
+	}
+
+	return vars, nil
+}
+
+func (w *Workflow) newContext(c Config, vars map[string]string) JobContext {
 	return JobContext{
-		Envs:   getEnvMap(),
+		Vars:   vars,
 		Logs:   []map[string]any{},
 		Config: c,
 	}
 }
 
 type JobContext struct {
-	Envs map[string]string `expr:"env"`
+	Vars map[string]string `expr:"vars"`
 	Logs []map[string]any  `expr:"steps"`
 	Config
 	Failed bool
@@ -69,7 +115,7 @@ func (j *JobContext) SetFailed() {
 }
 
 type TestContext struct {
-	Envs map[string]string `expr:"env"`
+	Vars map[string]string `expr:"vars"`
 	Logs []map[string]any  `expr:"steps"`
 	Res  map[string]any    `expr:"res"`
 	Req  map[string]any    `expr:"req"`
@@ -235,7 +281,7 @@ func (j *Job) Start(ctx JobContext) bool {
 
 func NewTestContext(j JobContext, req, res map[string]any) TestContext {
 	return TestContext{
-		Envs: j.Envs,
+		Vars: j.Vars,
 		Logs: j.Logs,
 		Req:  req,
 		Res:  res,

--- a/workflow.go
+++ b/workflow.go
@@ -146,12 +146,16 @@ type Job struct {
 
 func (j *Job) Start(ctx JobContext) bool {
 	j.ctx = &ctx
+	expr := NewExpr()
+
 	if j.Name == "" {
 		j.Name = "Unknown Job"
 	}
-	fmt.Printf("%s\n", j.Name)
-
-	expr := NewExpr()
+	name, err := expr.Eval(j.Name, ctx)
+	if err != nil {
+		return false
+	}
+	fmt.Printf("%s\n", name)
 
 	for i, st := range j.Steps {
 		if st.Name == "" {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestOsEnv(t *testing.T) {
+func TestEnv(t *testing.T) {
 	os.Setenv("HOST", "http://localhost")
 	os.Setenv("TOKEN", "secrets")
 	defer func() {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -1,0 +1,84 @@
+package probe
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestOsEnv(t *testing.T) {
+	os.Setenv("HOST", "http://localhost")
+	os.Setenv("TOKEN", "secrets")
+	defer func() {
+		os.Unsetenv("HOST")
+		os.Unsetenv("TOKEN")
+	}()
+
+	expected := map[string]string{
+		"HOST":  "http://localhost",
+		"TOKEN": "secrets",
+	}
+
+	wf := &Workflow{}
+	actual := wf.Env()
+
+	if actual["HOST"] != expected["HOST"] || actual["TOKEN"] != expected["TOKEN"] {
+		t.Errorf("expected %+v, got %+v", expected, actual)
+	}
+}
+
+func TestEvalVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		wf       *Workflow
+		expected map[string]string
+		err      error
+	}{
+		{
+			name: "use expr",
+			wf: &Workflow{
+				Name: "Test",
+				Vars: map[string]string{
+					"host":  "{HOST ?? 'http://localhost:3000'}",
+					"token": "{TOKEN}",
+				},
+				env: map[string]string{
+					"TOKEN": "secrets",
+				},
+			},
+			expected: map[string]string{
+				"host":  "http://localhost:3000",
+				"token": "secrets",
+			},
+			err: nil,
+		},
+		{
+			name: "not exists environment",
+			wf: &Workflow{
+				Name: "Test",
+				Vars: map[string]string{
+					"host":  "{HOST}",
+					"token": "{TOKEN}",
+				},
+				env: map[string]string{
+					"TOKEN": "secrets",
+				},
+			},
+			expected: nil,
+			err:      fmt.Errorf("environment(HOST) is nil"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := tt.wf.evalVars()
+			if err != nil && err.Error() != tt.err.Error() {
+				t.Errorf("expected error %+v, got %+v", tt.err, err)
+			}
+			if !reflect.DeepEqual(tt.expected, actual) {
+				t.Errorf("expected %+v, got %+v", tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Use environment variables only in the vars field:

- It also raises an error if the variable is empty
- Expand vars in workflow name