### PR TITLE
Support iterative steps

### DIFF
--- a/examples/iteration.yml
+++ b/examples/iteration.yml
@@ -1,0 +1,30 @@
+name: Iteration Step Example
+jobs:
+- name: Run iteration example
+  defaults:
+    http:
+      url: https://httpbin.org
+      headers:
+        content-type: application/json
+        accept: application/json
+  steps:
+  - name: "3 times iterations: {vars.name}"
+    uses: http
+    with:
+      post: /post
+      body:
+        id: "{vars.id}"
+        name: "{vars.name}"
+        role: "{vars.role}"
+    test: |
+      res.code == 200 &&
+      res.body.json.name == vars.name
+    echo: vars
+    vars:
+      id: 1234
+      name: default
+      role: admin
+    iter:
+    - {id: 2000, name: foo, role: user}
+    - {id: 3000, name: bar, role: editor}
+    - {id: 4000, name: baz, role: guest}

--- a/testdata/marshaled-workflow.yml
+++ b/testdata/marshaled-workflow.yml
@@ -16,6 +16,7 @@ jobs:
     test: ""
     echo: ""
     vars: {}
+    iter: {}
   repeat:
     count: 60
     interval: 10
@@ -36,6 +37,7 @@ jobs:
     test: ""
     echo: ""
     vars: {}
+    iter: {}
   repeat:
     count: 60
     interval: 10
@@ -56,6 +58,7 @@ jobs:
     test: ""
     echo: ""
     vars: {}
+    iter: {}
   repeat:
     count: 60
     interval: 10

--- a/testdata/marshaled-workflow.yml
+++ b/testdata/marshaled-workflow.yml
@@ -16,7 +16,7 @@ jobs:
     test: ""
     echo: ""
     vars: {}
-    iter: {}
+    iter: []
   repeat:
     count: 60
     interval: 10
@@ -37,7 +37,7 @@ jobs:
     test: ""
     echo: ""
     vars: {}
-    iter: {}
+    iter: []
   repeat:
     count: 60
     interval: 10
@@ -58,7 +58,7 @@ jobs:
     test: ""
     echo: ""
     vars: {}
-    iter: {}
+    iter: []
   repeat:
     count: 60
     interval: 10

--- a/workflow.go
+++ b/workflow.go
@@ -94,8 +94,8 @@ func (w *Workflow) newJobContext(c Config, vars map[string]any) JobContext {
 }
 
 type JobContext struct {
-	Vars map[string]any
-	Logs []map[string]any
+	Vars map[string]any   `expr:"vars"`
+	Logs []map[string]any `expr:"steps"`
 	Config
 	Failed bool
 }


### PR DESCRIPTION
This change causes the step to execute in iterations, and allows variables to be overwritten.

```yaml
steps:
- name: "Hi, {vars.name}"
  uses: http
  with:
    get: "/greeting/{vars.name}"
  iter:
  - {name: "Alice"}
  - {name: "Bob"}
```

The value assigned to `iter` object is expanded into `vars` object.