### PR TITLE
Support for response time option

### DIFF
--- a/cmd/probe/cmd.go
+++ b/cmd/probe/cmd.go
@@ -17,6 +17,7 @@ type Cmd struct {
 	Lint         bool
 	Help         bool
 	Verbose      bool
+	RT           bool
 	validFlags   []string
 	ver          string
 	rev          string
@@ -40,7 +41,7 @@ func newCmd(args []string) *Cmd {
 	}
 
 	c := Cmd{
-		validFlags: []string{"help", "init", "lint", "workflow", "verbose"},
+		validFlags: []string{"help", "init", "lint", "workflow", "rt", "verbose"},
 		ver:        version,
 		rev:        commit,
 	}
@@ -49,6 +50,7 @@ func newCmd(args []string) *Cmd {
 	flag.BoolVar(&c.Help, "help", false, "Show command usage")
 	flag.BoolVar(&c.Init, "init", false, "Export a workflow template as yaml file")
 	flag.BoolVar(&c.Lint, "lint", false, "Check the syntax in workflow")
+	flag.BoolVar(&c.RT, "rt", false, "Show response time")
 	flag.BoolVar(&c.Verbose, "verbose", false, "Show verbose log")
 
 	for _, arg := range args[1:] {
@@ -95,6 +97,9 @@ func (c *Cmd) start() int {
 	case c.Init:
 	default:
 		p := probe.New(c.WorkflowPath, c.Verbose)
+		if c.RT {
+			p.Config.RT = true
+		}
 		if err := p.Do(); err != nil {
 			fmt.Printf("%#v\n", err)
 		} else {

--- a/probe.go
+++ b/probe.go
@@ -13,20 +13,22 @@ import (
 type Probe struct {
 	FilePath string
 	workflow Workflow
-	config   Config
+	Config   Config
 }
 
 type Config struct {
 	Log     io.Writer
 	Verbose bool
+	RT      bool
 }
 
 func New(path string, v bool) *Probe {
 	return &Probe{
 		FilePath: path,
-		config: Config{
+		Config: Config{
 			Log:     os.Stdout,
 			Verbose: v,
+			RT:      false,
 		},
 	}
 }
@@ -36,7 +38,7 @@ func (p *Probe) Do() error {
 		return err
 	}
 
-	return p.workflow.Start(p.config)
+	return p.workflow.Start(p.Config)
 }
 
 func (p *Probe) ExitStatus() int {

--- a/probe_test.go
+++ b/probe_test.go
@@ -10,9 +10,10 @@ import (
 func TestLoad(t *testing.T) {
 	p := &Probe{
 		FilePath: "./testdata/workflow.yml",
-		config: Config{
+		Config: Config{
 			Log:     os.Stdout,
 			Verbose: true,
+			RT:      false,
 		},
 	}
 	err := p.Load()


### PR DESCRIPTION
The `--rt` option will show the response time for http actions.

![250208-0001](https://github.com/user-attachments/assets/74ace97d-c397-4dfb-8b0a-f5442aed3628)
