### PR TITLE
Rename results functionality to outputs with unified structure

### DIFF
--- a/examples/shared-outputs.yml
+++ b/examples/shared-outputs.yml
@@ -1,4 +1,4 @@
-name: Test Results Variables
+name: Test Outputs Variables
 
 x_defaults: &defaults
   http:
@@ -11,30 +11,30 @@ jobs:
   id: job1
   defaults: *defaults
   steps:
-  - name: Get my IP with set to results
+  - name: Get my IP with set to outputs
     id: step1
     uses: http
     with:
       get: /get
     echo: res.body.origin
-    results:
+    outputs:
       token: res.body.origin
-  - name: Post by results ip
+  - name: Post by outputs ip
     uses: http
     with:
       post: /post
       body:
-        myip: "{results.step1.token}"
+        myip: "{outputs.step1.token}"
     echo: res.body.json.myip
 
 - name: Test Job 2
   needs: [job1]
   defaults: *defaults
   steps:
-  - name: Use shared results over job
+  - name: Use shared outputs over job
     uses: http
     with:
       post: /post
       body:
-        myip: "{results.step1.token}"
-    echo: results.step1.token
+        myip: "{outputs.step1.token}"
+    echo: outputs.step1.token

--- a/job.go
+++ b/job.go
@@ -110,10 +110,8 @@ type JobContext struct {
 	UseBuffering bool
 	// Print writer
 	Printer PrintWriter
-	// Step results storage: stepID -> results map
-	Results map[string]map[string]any `expr:"results"`
-	// Shared results across all jobs (pointer to workflow results)
-	SharedResults *SharedResults
+	// Shared outputs across all jobs (accessible via expressions as "outputs")
+	Outputs *Outputs `expr:"outputs"`
 }
 
 func (j *JobContext) SetFailed() {
@@ -393,13 +391,13 @@ func (j *Job) validateSteps() error {
 			stepIDs[step.ID] = i
 		}
 
-		// Validate that results require an ID
-		if len(step.Results) > 0 && step.ID == "" {
+		// Validate that outputs require an ID
+		if len(step.Outputs) > 0 && step.ID == "" {
 			stepName := step.Name
 			if stepName == "" {
 				stepName = fmt.Sprintf("step %d", i)
 			}
-			return fmt.Errorf("%s: step with results must have an 'id' field", stepName)
+			return fmt.Errorf("%s: step with outputs must have an 'id' field", stepName)
 		}
 	}
 

--- a/job_executor.go
+++ b/job_executor.go
@@ -332,7 +332,7 @@ func (e *BufferedJobExecutor) finalizeJobExecution(jo *JobOutput, startTime time
 
 // printRepeatStepResults prints the final results of repeat step executions to buffer
 func (e *BufferedJobExecutor) printRepeatStepResults(ctx *JobContext, job *Job, jo *JobOutput) {
-	// Capture the step results output to buffer instead of printing directly
+	// Capture the step outputs output to buffer instead of printing directly
 	originalStdout := os.Stdout
 	r, wr, _ := os.Pipe()
 	os.Stdout = wr
@@ -346,13 +346,13 @@ func (e *BufferedJobExecutor) printRepeatStepResults(ctx *JobContext, job *Job, 
 		}
 	}
 
-	// Restore stdout and capture the step results
+	// Restore stdout and capture the step outputs
 	wr.Close()
 	os.Stdout = originalStdout
 
 	capturedOutput, _ := io.ReadAll(r)
 
-	// Add captured step results to job buffer
+	// Add captured step outputs to job buffer
 	jo.mutex.Lock()
 	jo.Buffer.Write(capturedOutput)
 	jo.mutex.Unlock()

--- a/job_executor_test.go
+++ b/job_executor_test.go
@@ -142,7 +142,7 @@ func TestBufferedJobExecutor_PrintRepeatStepResults(t *testing.T) {
 		t.Error("printRepeatStepResults should generate output")
 	}
 	
-	// Should contain step results (success ratio or similar indicator)
+	// Should contain step outputs (success ratio or similar indicator)
 	if !strings.Contains(output, "success") {
 		t.Errorf("Output should contain success indicator, got: %s", output)
 	}

--- a/job_test.go
+++ b/job_test.go
@@ -22,23 +22,23 @@ func TestJob_validateSteps(t *testing.T) {
 		{
 			name: "valid steps with results and id",
 			steps: []*Step{
-				{ID: "auth_step", Name: "Auth", Uses: "http", Results: map[string]string{"token": "{{ res.body.token }}"}},
+				{ID: "auth_step", Name: "Auth", Uses: "http", Outputs: map[string]string{"token": "{{ res.body.token }}"}},
 				{Name: "Simple step", Uses: "echo"},
 			},
 			expectErr: false,
 		},
 		{
-			name: "invalid: results without id",
+			name: "invalid: outputs without id",
 			steps: []*Step{
-				{Name: "Step with results but no id", Uses: "http", Results: map[string]string{"data": "{{ res.body }}"}},
+				{Name: "Step with outputs but no id", Uses: "http", Outputs: map[string]string{"data": "{{ res.body }}"}},
 			},
 			expectErr: true,
-			errMsg:    "step with results must have an 'id' field",
+			errMsg:    "step with outputs must have an 'id' field",
 		},
 		{
 			name: "invalid step id format - uppercase",
 			steps: []*Step{
-				{ID: "Auth_Step", Name: "Auth", Uses: "http", Results: map[string]string{"token": "{{ res.body.token }}"}},
+				{ID: "Auth_Step", Name: "Auth", Uses: "http", Outputs: map[string]string{"token": "{{ res.body.token }}"}},
 			},
 			expectErr: true,
 			errMsg:    "invalid step ID 'Auth_Step' - only [a-z0-9_-] characters are allowed",
@@ -46,7 +46,7 @@ func TestJob_validateSteps(t *testing.T) {
 		{
 			name: "invalid step id format - special chars",
 			steps: []*Step{
-				{ID: "auth@step", Name: "Auth", Uses: "http", Results: map[string]string{"token": "{{ res.body.token }}"}},
+				{ID: "auth@step", Name: "Auth", Uses: "http", Outputs: map[string]string{"token": "{{ res.body.token }}"}},
 			},
 			expectErr: true,
 			errMsg:    "invalid step ID 'auth@step' - only [a-z0-9_-] characters are allowed",
@@ -54,8 +54,8 @@ func TestJob_validateSteps(t *testing.T) {
 		{
 			name: "duplicate step ids",
 			steps: []*Step{
-				{ID: "auth_step", Name: "Auth 1", Uses: "http", Results: map[string]string{"token": "{{ res.body.token }}"}},
-				{ID: "auth_step", Name: "Auth 2", Uses: "http", Results: map[string]string{"data": "{{ res.body.data }}"}},
+				{ID: "auth_step", Name: "Auth 1", Uses: "http", Outputs: map[string]string{"token": "{{ res.body.token }}"}},
+				{ID: "auth_step", Name: "Auth 2", Uses: "http", Outputs: map[string]string{"data": "{{ res.body.data }}"}},
 			},
 			expectErr: true,
 			errMsg:    "duplicate step ID 'auth_step'",
@@ -63,9 +63,9 @@ func TestJob_validateSteps(t *testing.T) {
 		{
 			name: "valid step ids with allowed characters",
 			steps: []*Step{
-				{ID: "step_1", Name: "Step 1", Uses: "http", Results: map[string]string{"data": "{{ res.body }}"}},
-				{ID: "step-2", Name: "Step 2", Uses: "http", Results: map[string]string{"result": "{{ res.status }}"}},
-				{ID: "step3", Name: "Step 3", Uses: "http", Results: map[string]string{"count": "{{ res.body.count }}"}},
+				{ID: "step_1", Name: "Step 1", Uses: "http", Outputs: map[string]string{"data": "{{ res.body }}"}},
+				{ID: "step-2", Name: "Step 2", Uses: "http", Outputs: map[string]string{"result": "{{ res.status }}"}},
+				{ID: "step3", Name: "Step 3", Uses: "http", Outputs: map[string]string{"count": "{{ res.body.count }}"}},
 			},
 			expectErr: false,
 		},

--- a/workflow_executor.go
+++ b/workflow_executor.go
@@ -13,8 +13,8 @@ func (w *Workflow) Start(c Config) error {
 	output.PrintWorkflowHeader(w.Name, w.Description)
 
 	// Initialize shared results
-	if w.sharedResults == nil {
-		w.sharedResults = NewSharedResults()
+	if w.sharedOutputs == nil {
+		w.sharedOutputs = NewOutputs()
 	}
 
 	vars, err := w.evalVars()


### PR DESCRIPTION
- Rename Step.Results to Step.Outputs with YAML field `outputs:`
- Consolidate JobContext.Results and SharedResults into single Outputs structure
- Update JobContext to use unified Outputs pointer accessible via expressions as "outputs"
- Rename SharedResults struct to Outputs with updated method names
- Update saveResults() to saveOutputs() with simplified storage logic
- Update example files: shared-results.yml → shared-outputs.yml
- Update all expression access from results.stepid.name to outputs.stepid.name
- Fix validation messages and test cases for outputs terminology
- Maintain thread-safe cross-job data sharing with simplified architecture

🤖 Generated with [Claude Code](https://claude.ai/code)