### PR TITLE
Use {{ }} instead of { } for expr template

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -157,12 +157,12 @@ steps:
   with:
     get: /profile
     headers:
-      authorization: "Bearer {outputs.login.token}"
+      authorization: "Bearer {{outputs.login.token}}"
   test: res.code == 200
 ```
 
 ### 変数と式
-動的な値には`{expression}`構文を使用してください：
+動的な値には`{{expression}}`構文を使用してください：
 
 ```yaml
 vars:
@@ -173,8 +173,8 @@ steps:
 - name: ユーザー取得
   uses: http
   with:
-    url: "{vars.api_url}"
-    get: "/users/{vars.user_id}"
+    url: "{{vars.api_url}}"
+    get: "/users/{{vars.user_id}}"
   test: res.body.id == vars.user_id
 ```
 
@@ -213,7 +213,7 @@ test: |
   with:
     get: /protected
     headers:
-      authorization: "Bearer {outputs.auth.token}"
+      authorization: "Bearer {{outputs.auth.token}}"
 ```
 
 イテレーション
@@ -227,8 +227,8 @@ test: |
   with:
     post: /users
     body:
-      name: "{vars.name}"
-      role: "{vars.role}"
+      name: "{{vars.name}}"
+      role: "{{vars.role}}"
   test: res.code == 201
   iter:
   - {name: "Alice", role: "admin"}
@@ -327,15 +327,15 @@ test: |
 name: ユーザーAPI テスト
 vars:
   base_url: https://api.example.com
-  admin_token: "{env.ADMIN_TOKEN}"
+  admin_token: "{{env.ADMIN_TOKEN}}"
 
 jobs:
 - name: ユーザーCRUD操作
   defaults:
     http:
-      url: "{vars.base_url}"
+      url: "{{vars.base_url}}"
       headers:
-        authorization: "Bearer {vars.admin_token}"
+        authorization: "Bearer {{vars.admin_token}}"
         content-type: application/json
 
   steps:
@@ -354,7 +354,7 @@ jobs:
   - name: ユーザー取得
     uses: http
     with:
-      get: "/users/{outputs.create.user_id}"
+      get: "/users/{{outputs.create.user_id}}"
     test: |
       res.code == 200 &&
       res.body.name == "テストユーザー"
@@ -362,7 +362,7 @@ jobs:
   - name: ユーザー更新
     uses: http
     with:
-      put: "/users/{outputs.create.user_id}"
+      put: "/users/{{outputs.create.user_id}}"
       body:
         name: 更新されたユーザー
     test: res.code == 200
@@ -370,7 +370,7 @@ jobs:
   - name: ユーザー削除
     uses: http
     with:
-      delete: "/users/{outputs.create.user_id}"
+      delete: "/users/{{outputs.create.user_id}}"
     test: res.code == 204
 ```
 
@@ -480,7 +480,7 @@ jobs:
 ### よくある問題
 
 **式評価エラー**
-- 構文をチェック: `{expression}` 、 `{{expression}}`ではない
+- 構文をチェック: `{{expression}}` 、 `{expression}`ではない
 - 変数名とパスを確認
 - 文字列値は引用符で囲む
 

--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ steps:
   with:
     get: /profile
     headers:
-      authorization: "Bearer {outputs.login.token}"
+      authorization: "Bearer {{outputs.login.token}}"
   test: res.code == 200
 ```
 
 ### Variables and Expressions
-Use `{expression}` syntax for dynamic values:
+Use `{{expression}}` syntax for dynamic values:
 
 ```yaml
 vars:
@@ -173,8 +173,8 @@ steps:
 - name: Get User
   uses: http
   with:
-    url: "{vars.api_url}"
-    get: "/users/{vars.user_id}"
+    url: "{{vars.api_url}}"
+    get: "/users/{{vars.user_id}}"
   test: res.body.id == vars.user_id
 ```
 
@@ -211,7 +211,7 @@ Share data between steps and jobs:
   with:
     get: /protected
     headers:
-      authorization: "Bearer {outputs.auth.token}"
+      authorization: "Bearer {{outputs.auth.token}}"
 ```
 
 ### Iteration
@@ -223,8 +223,8 @@ Execute steps with different variable sets:
   with:
     post: /users
     body:
-      name: "{vars.name}"
-      role: "{vars.role}"
+      name: "{{vars.name}}"
+      role: "{{vars.role}}"
   test: res.code == 201
   iter:
   - {name: "Alice", role: "admin"}
@@ -317,15 +317,15 @@ Advanced Examples
 name: User API Test
 vars:
   base_url: https://api.example.com
-  admin_token: "{env.ADMIN_TOKEN}"
+  admin_token: "{{env.ADMIN_TOKEN}}"
 
 jobs:
 - name: User CRUD Operations
   defaults:
     http:
-      url: "{vars.base_url}"
+      url: "{{vars.base_url}}"
       headers:
-        authorization: "Bearer {vars.admin_token}"
+        authorization: "Bearer {{vars.admin_token}}"
         content-type: application/json
 
   steps:
@@ -344,7 +344,7 @@ jobs:
   - name: Get User
     uses: http
     with:
-      get: "/users/{outputs.create.user_id}"
+      get: "/users/{{outputs.create.user_id}}"
     test: |
       res.code == 200 &&
       res.body.name == "Test User"
@@ -352,7 +352,7 @@ jobs:
   - name: Update User
     uses: http
     with:
-      put: "/users/{outputs.create.user_id}"
+      put: "/users/{{outputs.create.user_id}}"
       body:
         name: Updated User
     test: res.code == 200
@@ -360,7 +360,7 @@ jobs:
   - name: Delete User
     uses: http
     with:
-      delete: "/users/{outputs.create.user_id}"
+      delete: "/users/{{outputs.create.user_id}}"
     test: res.code == 204
 ```
 
@@ -470,7 +470,7 @@ Troubleshooting
 ### Common Issues
 
 **Expression Evaluation Errors**
-- Check syntax: `{expression}` not `{{expression}}`
+- Check syntax: `{{expression}}` not `{expression}`
 - Verify variable names and paths
 - Use quotes around string values
 

--- a/examples/echo-multiline.yml
+++ b/examples/echo-multiline.yml
@@ -1,0 +1,33 @@
+name: Echo Multiline Test
+description: Test echo output with user-specified newlines and indentation
+
+jobs:
+- name: Test Echo Multiline
+  steps:
+  - name: Single line echo
+    uses: http
+    with:
+      url: https://httpbin.org/get
+      method: GET
+    echo: "Single line output"
+
+  - name: Multi-line echo with explicit newlines
+    uses: http
+    with:
+      url: https://httpbin.org/get
+      method: GET
+    echo: "Line 1\nLine 2\nLine 3"
+
+  - name: Complex multiline echo
+    uses: http
+    with:
+      url: https://httpbin.org/get
+      method: GET
+    echo: "Header line\n  Indented content\n    More indented\nBack to left\n\nEmpty line above"
+
+  - name: Echo with template expressions
+    uses: http
+    with:
+      url: https://httpbin.org/get
+      method: GET
+    echo: "Response URL: {{res.body.url}}\nStatus: {{res.code}}\nMultiline template result"

--- a/examples/iteration.yml
+++ b/examples/iteration.yml
@@ -8,14 +8,14 @@ jobs:
         content-type: application/json
         accept: application/json
   steps:
-  - name: "3 times iterations: {vars.name}"
+  - name: "3 times iterations: {{vars.name}}"
     uses: http
     with:
       post: /post
       body:
-        id: "{vars.id}"
-        name: "{vars.name}"
-        role: "{vars.role}"
+        id: "{{vars.id}}"
+        name: "{{vars.name}}"
+        role: "{{vars.role}}"
     test: |
       res.code == 200 &&
       res.body.json.name == vars.name

--- a/examples/needs-test.yml
+++ b/examples/needs-test.yml
@@ -17,7 +17,7 @@ jobs:
       post: /post
       body:
         message: "Setup completed"
-        setup_id: "{random_int(9999)}"
+        setup_id: "{{random_int(9999)}}"
     test: res.code == 200
     echo: res.body.json.setup_id
 

--- a/examples/rest.yml
+++ b/examples/rest.yml
@@ -1,14 +1,14 @@
 name: REST API Example
 vars:
-  token: "{TOKEN ?? 'secret'}"
-  url: "{URL ?? 'https://httpbin.org'}"
+  token: "{{TOKEN ?? 'secret'}}"
+  url: "{{URL ?? 'https://httpbin.org'}}"
 jobs:
-- name: "Request to {vars.url}"
+- name: "Request to {{vars.url}}"
   defaults:
     http:
-      url: "{vars.url}"
+      url: "{{vars.url}}"
       headers:
-        authorization: "Bearer {vars.token}"
+        authorization: "Bearer {{vars.token}}"
         content-type: application/json
         accept: application/json
   steps:
@@ -34,7 +34,7 @@ jobs:
     with:
       put: /put
       body:
-        ip: "{steps[0].res.body.origin}"
+        ip: "{{steps[0].res.body.origin}}"
     test: |
       res.code == 200 &&
       res.body.json.ip == steps[0].res.body.origin

--- a/examples/shared-outputs.yml
+++ b/examples/shared-outputs.yml
@@ -16,7 +16,7 @@ jobs:
     uses: http
     with:
       get: /get
-    echo: "{res.body.origin}"
+    echo: "{{res.body.origin}}"
     outputs:
       token: res.body.origin
 
@@ -25,11 +25,11 @@ jobs:
     with:
       post: /post
       body:
-        myip: "{outputs.step1.token}"
-    echo: "myip: {res.body.json.myip}\nbar:{vars.foo.bar}"
+        myip: "{{outputs.step1.token}}"
+    echo: "myip: {{res.body.json.myip}}\nbar:{{vars.foo.bar}}"
     vars:
       foo:
-        bar: "{outputs.step1.token}"
+        bar: "{{outputs.step1.token}}"
 
 - name: Test Job 2
   needs: [job1]
@@ -40,5 +40,5 @@ jobs:
     with:
       post: /post
       body:
-        myip: "{outputs.step1.token}"
-    echo: "{outputs.step1.token}"
+        myip: "{{outputs.step1.token}}"
+    echo: "{{outputs.step1.token}}"

--- a/examples/shared-outputs.yml
+++ b/examples/shared-outputs.yml
@@ -16,16 +16,20 @@ jobs:
     uses: http
     with:
       get: /get
-    echo: res.body.origin
+    echo: "{res.body.origin}"
     outputs:
       token: res.body.origin
+
   - name: Post by outputs ip
     uses: http
     with:
       post: /post
       body:
         myip: "{outputs.step1.token}"
-    echo: res.body.json.myip
+    echo: "myip: {res.body.json.myip}\nbar:{vars.foo.bar}"
+    vars:
+      foo:
+        bar: "{outputs.step1.token}"
 
 - name: Test Job 2
   needs: [job1]
@@ -37,4 +41,4 @@ jobs:
       post: /post
       body:
         myip: "{outputs.step1.token}"
-    echo: outputs.step1.token
+    echo: "{outputs.step1.token}"

--- a/examples/truncate.yml
+++ b/examples/truncate.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       post: /post
       body:
-        content: "{random_str(2000)}"
+        content: "{{random_str(2000)}}"
     test: |
       res.code == 200
-    echo: "Response body: {res.body}"
+    echo: "Response body: {{res.body}}"

--- a/examples/truncate.yml
+++ b/examples/truncate.yml
@@ -1,0 +1,20 @@
+name: Truncate Strings Test
+
+jobs:
+- name: Display truncated text
+  defaults:
+    http:
+      url: https://httpbin.org
+      headers:
+        content-type: application/json
+        accept: application/json
+  steps:
+  - name: Post long content
+    uses: http
+    with:
+      post: /post
+      body:
+        content: "{random_str(2000)}"
+    test: |
+      res.code == 200
+    echo: "Response body: {res.body}"

--- a/expr.go
+++ b/expr.go
@@ -13,10 +13,10 @@ import (
 )
 
 var (
-	// Regular expression to find `{ ... }` patterns
-	templateRegexp = regexp.MustCompile(`\{([^{}]+)\}`)
-	templateStart  = "{"
-	templateEnd    = "}"
+	// Regular expression to find `{{ ... }}` patterns
+	templateRegexp = regexp.MustCompile(`\{\{([^{}]+)\}\}`)
+	templateStart  = "{{"
+	templateEnd    = "}}"
 
 	// Security: Maximum expression length and evaluation timeout
 	maxExpressionLength = 1000000
@@ -377,8 +377,13 @@ func (e *Expr) EvalTemplate(input string, env any) (string, error) {
 			return match
 		}
 
-		// Extract the expression inside `{ ... }`
-		expression := strings.TrimSpace(string(match[1 : len(match)-1]))
+		// Extract the expression inside `{{ ... }}` using submatch
+		submatch := re.FindStringSubmatch(string(match))
+		if len(submatch) < 2 {
+			evalError = fmt.Errorf("invalid template expression: %s", string(match))
+			return []byte(fmt.Sprintf("[TemplateError: invalid expression]"))
+		}
+		expression := strings.TrimSpace(submatch[1])
 
 		// Security: Validate individual expression
 		if err := e.validateExpression(expression); err != nil {

--- a/expr.go
+++ b/expr.go
@@ -381,7 +381,7 @@ func (e *Expr) EvalTemplate(input string, env any) (string, error) {
 		submatch := re.FindStringSubmatch(string(match))
 		if len(submatch) < 2 {
 			evalError = fmt.Errorf("invalid template expression: %s", string(match))
-			return []byte(fmt.Sprintf("[TemplateError: invalid expression]"))
+			return []byte("[TemplateError: invalid expression]")
 		}
 		expression := strings.TrimSpace(submatch[1])
 

--- a/expr_test.go
+++ b/expr_test.go
@@ -372,7 +372,7 @@ func TestValueSanitization(t *testing.T) {
 			t.Errorf("truncated string should contain truncation marker")
 		}
 		// Check that the original long part was truncated to maxStringLength
-		truncationMsg := getTruncationMessage()
+		truncationMsg := GetTruncationMessage()
 		originalContent := strings.Replace(resultStr, truncationMsg, "", 1)
 		if len(originalContent) > 1000000 {
 			t.Errorf("string content should be truncated to %d chars, got %d", 1000000, len(originalContent))

--- a/expr_test.go
+++ b/expr_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestEvalTemplateMap(t *testing.T) {
 	exprs := map[string]any{
-		"url":           "{env.URL}",
-		"authorization": "Bearer {env.TOKEN}",
+		"url":           "{{env.URL}}",
+		"authorization": "Bearer {{env.TOKEN}}",
 	}
 	env := map[string]any{
 		"env": map[string]any{
@@ -39,7 +39,7 @@ func TestEvalTemplate(t *testing.T) {
 	}{
 		{
 			name: "only variable",
-			str:  "{env.URL}",
+			str:  "{{env.URL}}",
 			env: map[string]any{
 				"env": map[string]any{
 					"URL": "https://example.com",
@@ -49,7 +49,7 @@ func TestEvalTemplate(t *testing.T) {
 		},
 		{
 			name: "expr twice",
-			str:  "Hi, { name }. My name is { service }.",
+			str:  "Hi, {{ name }}. My name is {{ service }}.",
 			env: map[string]any{
 				"name":    "Bob",
 				"service": "Alice",
@@ -58,7 +58,7 @@ func TestEvalTemplate(t *testing.T) {
 		},
 		{
 			name: "use nil coalescing operator",
-			str:  "{env.URL ?? 'http://localhost'}",
+			str:  "{{env.URL ?? 'http://localhost'}}",
 			env: map[string]any{
 				"env": map[string]any{},
 			},
@@ -66,7 +66,7 @@ func TestEvalTemplate(t *testing.T) {
 		},
 		{
 			name: "use ternary operator",
-			str:  "{env.URL == 'localhost' ? 'http://localhost:3000' : env.URL}",
+			str:  "{{env.URL == 'localhost' ? 'http://localhost:3000' : env.URL}}",
 			env: map[string]any{
 				"env": map[string]any{
 					"URL": "localhost",
@@ -160,7 +160,7 @@ func TestEvalOrEvalTemplate(t *testing.T) {
 		},
 		{
 			name:  "template with variable",
-			input: "Hello {name}!",
+			input: "Hello {{name}}!",
 			env: map[string]any{
 				"name": "World",
 			},
@@ -406,7 +406,7 @@ func TestErrorHandling(t *testing.T) {
 
 	t.Run("handles template evaluation errors", func(t *testing.T) {
 		expr := &Expr{}
-		result, err := expr.EvalTemplate("{invalid syntax $$}", map[string]any{})
+		result, err := expr.EvalTemplate("{{invalid syntax $$}}", map[string]any{})
 
 		if err == nil && !strings.Contains(result, "CompileError") {
 			t.Errorf("expected compilation error in template")
@@ -417,7 +417,7 @@ func TestErrorHandling(t *testing.T) {
 		expr := &Expr{}
 		inputMap := map[string]any{
 			"valid":   "simple string",
-			"invalid": "{invalid syntax $$}",
+			"invalid": "{{invalid syntax $$}}",
 		}
 
 		result := expr.EvalTemplateMap(inputMap, map[string]any{})
@@ -426,7 +426,7 @@ func TestErrorHandling(t *testing.T) {
 			t.Errorf("valid expression should work")
 		}
 		// The actual error message may vary, just check it's not the original invalid template
-		if result["invalid"] == "{invalid syntax $$}" {
+		if result["invalid"] == "{{invalid syntax $$}}" {
 			t.Errorf("invalid expression should be processed and not return original template")
 		}
 	})
@@ -679,19 +679,19 @@ func TestNewCustomFunctions(t *testing.T) {
 		}{
 			{
 				name:     "random_int in template",
-				template: "User ID: {random_int(9999)}",
+				template: "User ID: {{random_int(9999)}}",
 			},
 			{
 				name:     "random_str in template",
-				template: "Session: {random_str(16)}",
+				template: "Session: {{random_str(16)}}",
 			},
 			{
 				name:     "unixtime in template",
-				template: "Timestamp: {unixtime()}",
+				template: "Timestamp: {{unixtime()}}",
 			},
 			{
 				name:     "multiple functions in template",
-				template: "ID: {random_int(1000)}, Token: {random_str(8)}, Time: {unixtime()}",
+				template: "ID: {{random_int(1000)}}, Token: {{random_str(8)}}, Time: {{unixtime()}}",
 			},
 		}
 

--- a/printer_test.go
+++ b/printer_test.go
@@ -722,6 +722,10 @@ func TestTruncateString(t *testing.T) {
 }
 
 func TestTruncateMapStringString(t *testing.T) {
+	// Disable color output for consistent testing
+	color.NoColor = true
+	defer func() { color.NoColor = false }()
+
 	tests := []struct {
 		name     string
 		input    map[string]string
@@ -810,8 +814,8 @@ func TestMaxLogStringLength(t *testing.T) {
 		t.Errorf("MaxLogStringLength should be positive, got %d", MaxLogStringLength)
 	}
 
-	// Test that it has a reasonable value (expected to be 1000)
-	expectedValue := 1000
+	// Test that it has a reasonable value (expected to be 200)
+	expectedValue := 200
 	if MaxLogStringLength != expectedValue {
 		t.Errorf("MaxLogStringLength = %d, expected %d", MaxLogStringLength, expectedValue)
 	}

--- a/step.go
+++ b/step.go
@@ -403,7 +403,7 @@ func (st *Step) updateCtx(logs []map[string]any, req, res map[string]any, rt str
 }
 
 func (st *Step) ShowRequestResponse(name string, jCtx *JobContext) {
-	jCtx.Printer.LogDebug(colorWarning().Sprintf("--- Step %d: %s", st.idx, name))
+	jCtx.Printer.LogDebug("%s", colorWarning().Sprintf("--- Step %d: %s", st.idx, name))
 	jCtx.Printer.LogDebug("Request:")
 	st.printMapData(st.ctx.Req, jCtx)
 
@@ -541,7 +541,7 @@ func (st *Step) shouldSkip(jCtx *JobContext) bool {
 // handleSkip handles the skipped step logic
 func (st *Step) handleSkip(name string, jCtx *JobContext) {
 	if jCtx.Config.Verbose {
-		jCtx.Printer.LogDebug(colorWarning().Sprintf("--- Step %d: %s (SKIPPED)", st.idx, name))
+		jCtx.Printer.LogDebug("%s", colorWarning().Sprintf("--- Step %d: %s (SKIPPED)", st.idx, name))
 		jCtx.Printer.LogDebug("Skip condition: %s", st.SkipIf)
 		jCtx.Printer.PrintSeparator()
 		return

--- a/step.go
+++ b/step.go
@@ -7,8 +7,6 @@ import (
 	"time"
 )
 
-
-
 type Step struct {
 	Name    string            `yaml:"name"`
 	ID      string            `yaml:"id,omitempty"`
@@ -211,7 +209,7 @@ func (st *Step) createStepResult(name, rt string, okrt bool, jCtx *JobContext, r
 
 // getEchoOutput returns the echo output as string
 func (st *Step) getEchoOutput() string {
-	exprOut, err := st.expr.Eval(st.Echo, st.ctx)
+	exprOut, err := st.expr.EvalTemplate(st.Echo, st.ctx)
 	if err != nil {
 		return fmt.Sprintf("Echo\nerror: %#v\n", err)
 	}
@@ -294,7 +292,7 @@ func (st *Step) DoTestWithSequentialPrint(jCtx *JobContext) bool {
 }
 
 func (st *Step) DoEchoWithSequentialPrint(jCtx *JobContext) {
-	exprOut, err := st.expr.Eval(st.Echo, st.ctx)
+	exprOut, err := st.expr.EvalTemplate(st.Echo, st.ctx)
 	if err != nil {
 		jCtx.Printer.LogError("Echo Error: %#v (input: %s)", err, st.Echo)
 	} else {
@@ -324,7 +322,7 @@ func (st *Step) DoTest() (string, bool) {
 }
 
 func (st *Step) DoEcho(jCtx *JobContext) {
-	exprOut, err := st.expr.Eval(st.Echo, st.ctx)
+	exprOut, err := st.expr.EvalTemplate(st.Echo, st.ctx)
 	if err != nil {
 		jCtx.Printer.LogError("Echo evaluation failed: %#v", err)
 	} else {
@@ -360,7 +358,7 @@ func (st *Step) updateCtx(logs []map[string]any, req, res map[string]any, rt str
 }
 
 func (st *Step) ShowRequestResponse(name string, jCtx *JobContext) {
-	jCtx.Printer.LogDebug("--- Step %d: %s", st.idx, name)
+	jCtx.Printer.LogDebug(colorWarning().Sprintf("--- Step %d: %s", st.idx, name))
 	jCtx.Printer.LogDebug("Request:")
 	st.printMapData(st.ctx.Req, jCtx)
 
@@ -498,7 +496,7 @@ func (st *Step) shouldSkip(jCtx *JobContext) bool {
 // handleSkip handles the skipped step logic
 func (st *Step) handleSkip(name string, jCtx *JobContext) {
 	if jCtx.Config.Verbose {
-		jCtx.Printer.LogDebug("--- Step %d: %s (SKIPPED)", st.idx, name)
+		jCtx.Printer.LogDebug(colorWarning().Sprintf("--- Step %d: %s (SKIPPED)", st.idx, name))
 		jCtx.Printer.LogDebug("Skip condition: %s", st.SkipIf)
 		jCtx.Printer.PrintSeparator()
 		return

--- a/step.go
+++ b/step.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -213,7 +214,17 @@ func (st *Step) getEchoOutput() string {
 	if err != nil {
 		return fmt.Sprintf("Echo\nerror: %#v\n", err)
 	}
-	return fmt.Sprintf("       %s\n", exprOut)
+	
+	// Add indent to all lines, including after user-specified newlines
+	indent := "       "
+	lines := strings.Split(exprOut, "\n")
+	indentedLines := make([]string, len(lines))
+	
+	for i, line := range lines {
+		indentedLines[i] = indent + line
+	}
+	
+	return strings.Join(indentedLines, "\n") + "\n"
 }
 
 func (st *Step) handleRepeatExecution(jCtx *JobContext, name, rt string, okrt bool) {
@@ -326,8 +337,13 @@ func (st *Step) DoEcho(jCtx *JobContext) {
 	if err != nil {
 		jCtx.Printer.LogError("Echo evaluation failed: %#v", err)
 	} else {
-		// 7 spaces
-		jCtx.Printer.LogDebug("       %s", exprOut)
+		// Add indent to all lines, including after user-specified newlines
+		indent := "       "
+		lines := strings.Split(exprOut, "\n")
+		
+		for _, line := range lines {
+			jCtx.Printer.LogDebug("%s%s", indent, line)
+		}
 	}
 }
 

--- a/testdata/failure.yml
+++ b/testdata/failure.yml
@@ -6,6 +6,6 @@ jobs:
   - name: Failure Step
     uses: http
     with:
-      url: "{env.TEST_SERVER_URL ? env.TEST_SERVER_URL : \"https://httpbin.org\"}"
+      url: "{{env.TEST_SERVER_URL ? env.TEST_SERVER_URL : \"https://httpbin.org\"}}"
       get: /status/404
     test: res.code == 200

--- a/testdata/success.yml
+++ b/testdata/success.yml
@@ -6,6 +6,6 @@ jobs:
   - name: Success Step
     uses: http
     with:
-      url: "{env.TEST_SERVER_URL ? env.TEST_SERVER_URL : \"https://httpbin.org\"}"
+      url: "{{env.TEST_SERVER_URL ? env.TEST_SERVER_URL : \"https://httpbin.org\"}}"
       get: /status/200
     test: res.code == 200

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -632,8 +632,8 @@ func TestEvalVars(t *testing.T) {
 			wf: &Workflow{
 				Name: "Test",
 				Vars: map[string]any{
-					"host":  "{HOST ?? 'http://localhost:3000'}",
-					"token": "{TOKEN}",
+					"host":  "{{HOST ?? 'http://localhost:3000'}}",
+					"token": "{{TOKEN}}",
 				},
 				env: map[string]string{
 					"TOKEN": "secrets",
@@ -650,8 +650,8 @@ func TestEvalVars(t *testing.T) {
 			wf: &Workflow{
 				Name: "Test",
 				Vars: map[string]any{
-					"host":  "{HOST}",
-					"token": "{TOKEN}",
+					"host":  "{{HOST}}",
+					"token": "{{TOKEN}}",
 				},
 				env: map[string]string{
 					"TOKEN": "secrets",


### PR DESCRIPTION
Change the template syntax from { } to {{ }}. This will distinguish it from the use of { } in regular expressions, etc.