### PR TITLE
refactor: separate output formatting responsibilities between step.go…

### DIFF
--- a/step_test.go
+++ b/step_test.go
@@ -950,8 +950,9 @@ func TestStep_getEchoOutput(t *testing.T) {
 				ctx:  tt.context,
 				expr: &Expr{},
 			}
+			printer := NewPrinter(false, []string{})
 
-			result := step.getEchoOutput()
+			result := step.getEchoOutput(printer)
 
 			if result != tt.expected {
 				t.Errorf("getEchoOutput() = %q, want %q", result, tt.expected)
@@ -966,8 +967,9 @@ func TestStep_getEchoOutput_Error(t *testing.T) {
 		ctx:  StepContext{},
 		expr: &Expr{},
 	}
+	printer := NewPrinter(false, []string{})
 
-	result := step.getEchoOutput()
+	result := step.getEchoOutput(printer)
 
 	// Should contain error indication when template evaluation fails
 	if !strings.Contains(result, "CompileError") && !strings.Contains(result, "RuntimeError") && !strings.Contains(result, "Echo\nerror:") {


### PR DESCRIPTION
… and printer.go

- Add new generate* formatting functions to printer.go for echo, test outputs
- Update step.go functions to delegate formatting to printer.go while keeping expression evaluation
- Remove deprecated helper functions from step.go (printMapData, printNestedMap)
- Clean up unused imports (strings) from step.go
- Update tests to use new function signatures

This separation improves maintainability by clearly dividing responsibilities:
- step.go: expression evaluation and business logic
- printer.go: output formatting and display logic

🤖 Generated with [Claude Code](https://claude.ai/code)