### PR TITLE
Workflow option to positional argument

### DIFF
--- a/actions_test.go
+++ b/actions_test.go
@@ -1,0 +1,373 @@
+package probe
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/linyows/probe/pb"
+	"google.golang.org/grpc"
+)
+
+// MockActions implements the Actions interface for testing
+type MockActions struct {
+	RunFunc func(args []string, with map[string]string) (map[string]string, error)
+}
+
+func (m *MockActions) Run(args []string, with map[string]string) (map[string]string, error) {
+	if m.RunFunc != nil {
+		return m.RunFunc(args, with)
+	}
+	return map[string]string{"result": "success"}, nil
+}
+
+// MockActionsClient for testing ActionsClient without GRPC
+type MockActionsClient struct {
+	client pb.ActionsClient
+}
+
+func (m *MockActionsClient) Run(args []string, with map[string]string) (map[string]string, error) {
+	// For unit testing, we can simulate the behavior without actual GRPC calls
+	if len(args) == 0 {
+		return nil, errors.New("no arguments provided")
+	}
+	
+	result := map[string]string{
+		"action": args[0],
+		"status": "completed",
+	}
+	
+	// Include parameters in result
+	for k, v := range with {
+		result[k] = v
+	}
+	
+	return result, nil
+}
+
+func TestActionsTypes(t *testing.T) {
+	// Test that the basic types and constants are defined correctly
+	if BuiltinCmd == "" {
+		t.Error("BuiltinCmd should not be empty")
+	}
+	
+	expectedBuiltinCmd := "builtin-actions"
+	if BuiltinCmd != expectedBuiltinCmd {
+		t.Errorf("BuiltinCmd = %q, want %q", BuiltinCmd, expectedBuiltinCmd)
+	}
+	
+	// Test HandshakeConfig
+	if Handshake.ProtocolVersion != 1 {
+		t.Errorf("Handshake.ProtocolVersion = %d, want 1", Handshake.ProtocolVersion)
+	}
+	
+	if Handshake.MagicCookieKey != "probe" {
+		t.Errorf("Handshake.MagicCookieKey = %q, want %q", Handshake.MagicCookieKey, "probe")
+	}
+	
+	if Handshake.MagicCookieValue != "actions" {
+		t.Errorf("Handshake.MagicCookieValue = %q, want %q", Handshake.MagicCookieValue, "actions")
+	}
+	
+	// Test PluginMap
+	if len(PluginMap) != 1 {
+		t.Errorf("PluginMap length = %d, want 1", len(PluginMap))
+	}
+	
+	if _, exists := PluginMap["actions"]; !exists {
+		t.Error("PluginMap should contain 'actions' key")
+	}
+}
+
+func TestActionsPlugin_GRPCServer(t *testing.T) {
+	plugin := &ActionsPlugin{
+		Impl: &MockActions{},
+	}
+	
+	// Create a valid gRPC server for testing
+	server := grpc.NewServer()
+	defer server.Stop()
+	
+	// Test that GRPCServer method exists and returns nil for valid input
+	err := plugin.GRPCServer(nil, server)
+	if err != nil {
+		t.Errorf("GRPCServer() returned error: %v", err)
+	}
+}
+
+func TestActionsPlugin_GRPCClient(t *testing.T) {
+	plugin := &ActionsPlugin{}
+	
+	// Test that GRPCClient method exists and can be called
+	// We can't easily test the actual GRPC client creation without complex setup
+	client, err := plugin.GRPCClient(context.Background(), nil, nil)
+	if err != nil {
+		t.Errorf("GRPCClient() returned error: %v", err)
+	}
+	
+	// Verify the client is of the expected type
+	if _, ok := client.(*ActionsClient); !ok {
+		t.Errorf("GRPCClient() returned wrong type: %T", client)
+	}
+}
+
+func TestActionsClient_Run(t *testing.T) {
+	// Since we can't easily mock the GRPC client, we'll test the interface
+	// and create a mock implementation for testing
+	mockClient := &MockActionsClient{}
+	
+	tests := []struct {
+		name        string
+		args        []string
+		with        map[string]string
+		expectError bool
+		expectKeys  []string
+	}{
+		{
+			name:        "successful run with args",
+			args:        []string{"test-action"},
+			with:        map[string]string{"param1": "value1"},
+			expectError: false,
+			expectKeys:  []string{"action", "status", "param1"},
+		},
+		{
+			name:        "successful run with multiple params",
+			args:        []string{"complex-action"},
+			with:        map[string]string{"url": "http://example.com", "method": "GET"},
+			expectError: false,
+			expectKeys:  []string{"action", "status", "url", "method"},
+		},
+		{
+			name:        "empty args should fail",
+			args:        []string{},
+			with:        map[string]string{},
+			expectError: true,
+			expectKeys:  nil,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := mockClient.Run(tt.args, tt.with)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			
+			// Check that expected keys are present
+			for _, key := range tt.expectKeys {
+				if _, exists := result[key]; !exists {
+					t.Errorf("expected key %q not found in result", key)
+				}
+			}
+			
+			// Check specific values
+			if len(tt.args) > 0 && result["action"] != tt.args[0] {
+				t.Errorf("result[action] = %q, want %q", result["action"], tt.args[0])
+			}
+		})
+	}
+}
+
+func TestActionsServer_Run(t *testing.T) {
+	tests := []struct {
+		name        string
+		mockFunc    func(args []string, with map[string]string) (map[string]string, error)
+		args        []string
+		with        map[string]string
+		expectError bool
+		expectedRes map[string]string
+	}{
+		{
+			name: "successful run",
+			mockFunc: func(args []string, with map[string]string) (map[string]string, error) {
+				return map[string]string{
+					"status": "success",
+					"action": args[0],
+				}, nil
+			},
+			args:        []string{"test-action"},
+			with:        map[string]string{"param": "value"},
+			expectError: false,
+			expectedRes: map[string]string{
+				"status": "success",
+				"action": "test-action",
+			},
+		},
+		{
+			name: "error case",
+			mockFunc: func(args []string, with map[string]string) (map[string]string, error) {
+				return nil, errors.New("mock error")
+			},
+			args:        []string{"failing-action"},
+			with:        map[string]string{},
+			expectError: true,
+			expectedRes: nil,
+		},
+		{
+			name: "empty result",
+			mockFunc: func(args []string, with map[string]string) (map[string]string, error) {
+				return map[string]string{}, nil
+			},
+			args:        []string{"empty-action"},
+			with:        map[string]string{},
+			expectError: false,
+			expectedRes: map[string]string{},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockActions := &MockActions{
+				RunFunc: tt.mockFunc,
+			}
+			
+			server := &ActionsServer{
+				Impl: mockActions,
+			}
+			
+			req := &pb.RunRequest{
+				Args: tt.args,
+				With: tt.with,
+			}
+			
+			resp, err := server.Run(context.Background(), req)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			
+			if resp == nil {
+				t.Fatal("response should not be nil")
+			}
+			
+			// Compare results
+			if len(resp.Result) != len(tt.expectedRes) {
+				t.Errorf("result length = %d, want %d", len(resp.Result), len(tt.expectedRes))
+			}
+			
+			for k, v := range tt.expectedRes {
+				if resp.Result[k] != v {
+					t.Errorf("result[%q] = %q, want %q", k, resp.Result[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestMockActions_Run(t *testing.T) {
+	// Test the mock implementation itself
+	t.Run("default behavior", func(t *testing.T) {
+		mock := &MockActions{}
+		
+		result, err := mock.Run([]string{"test"}, map[string]string{"key": "value"})
+		
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		
+		expected := map[string]string{"result": "success"}
+		if len(result) != len(expected) {
+			t.Errorf("result length = %d, want %d", len(result), len(expected))
+		}
+		
+		if result["result"] != "success" {
+			t.Errorf("result[result] = %q, want %q", result["result"], "success")
+		}
+	})
+	
+	t.Run("custom function", func(t *testing.T) {
+		mock := &MockActions{
+			RunFunc: func(args []string, with map[string]string) (map[string]string, error) {
+				return map[string]string{
+					"custom": "response",
+					"args_count": string(rune(len(args))),
+				}, nil
+			},
+		}
+		
+		result, err := mock.Run([]string{"arg1", "arg2"}, map[string]string{})
+		
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		
+		if result["custom"] != "response" {
+			t.Errorf("result[custom] = %q, want %q", result["custom"], "response")
+		}
+	})
+	
+	t.Run("error case", func(t *testing.T) {
+		mock := &MockActions{
+			RunFunc: func(args []string, with map[string]string) (map[string]string, error) {
+				return nil, errors.New("test error")
+			},
+		}
+		
+		result, err := mock.Run([]string{}, map[string]string{})
+		
+		if err == nil {
+			t.Error("expected error but got none")
+		}
+		
+		if result != nil {
+			t.Errorf("result should be nil on error, got %v", result)
+		}
+	})
+}
+
+// Test type definitions and interfaces
+func TestActionsInterface(t *testing.T) {
+	// Test that MockActions implements Actions interface
+	var _ Actions = &MockActions{}
+	
+	// Test that ActionsClient implements Actions interface  
+	var _ Actions = &ActionsClient{}
+	
+	// Test type aliases
+	var args ActionsArgs = []string{"test"}
+	if len(args) != 1 {
+		t.Errorf("ActionsArgs length = %d, want 1", len(args))
+	}
+	
+	var params ActionsParams = map[string]string{"key": "value"}
+	if len(params) != 1 {
+		t.Errorf("ActionsParams length = %d, want 1", len(params))
+	}
+}
+
+// Note: RunActions function is complex to test because it:
+// 1. Creates actual plugin clients
+// 2. Executes external processes
+// 3. Uses GRPC communication
+// 
+// For comprehensive testing of RunActions, you would need:
+// - Mock plugin system
+// - Test doubles for exec.Command
+// - Integration test environment
+// 
+// This is typically tested through integration tests rather than unit tests.
+func TestRunActions_Structure(t *testing.T) {
+	// We can only test that the function signature exists and compiles
+	var _ func(string, []string, map[string]any, bool) (map[string]any, error) = RunActions
+	
+	// Test that the function handles the basic parameter transformation
+	// In a real scenario, this would require a full plugin setup
+	t.Log("RunActions function signature verified")
+}

--- a/cmd/probe/cmd.go
+++ b/cmd/probe/cmd.go
@@ -42,7 +42,7 @@ func newCmd(args []string) *Cmd {
 	}
 
 	c := Cmd{
-		validFlags: []string{"help", "rt", "verbose"},
+		validFlags: []string{"help", "rt", "verbose", "v"},
 		ver:        version,
 		rev:        commit,
 	}
@@ -52,6 +52,7 @@ func newCmd(args []string) *Cmd {
 	//flag.BoolVar(&c.Lint, "lint", false, "Check the syntax in workflow")
 	flag.BoolVar(&c.RT, "rt", false, "Show response time")
 	flag.BoolVar(&c.Verbose, "verbose", false, "Show verbose log")
+	flag.BoolVar(&c.Verbose, "v", false, "Show verbose log (shorthand)")
 
 	for _, arg := range args[1:] {
 		if strings.HasPrefix(arg, "-") && !c.isValid(arg) {

--- a/cmd/probe/cmd.go
+++ b/cmd/probe/cmd.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/linyows/probe"
 	"github.com/linyows/probe/actions/hello"
 	http "github.com/linyows/probe/actions/http"
@@ -66,12 +67,12 @@ func newCmd(args []string) *Cmd {
 	}
 
 	flag.Parse()
-	
+
 	// Set WorkflowPath from first non-flag argument
 	if flag.NArg() > 0 {
 		c.WorkflowPath = flag.Arg(0)
 	}
-	
+
 	return &c
 }
 
@@ -90,25 +91,33 @@ func (c *Cmd) isValid(flag string) bool {
 }
 
 func (c *Cmd) usage() {
-	h := `
+	logo := `
  __  __  __  __  __
 |  ||  ||  ||  || _|
 |  ||  /| |||  /|  |
 | | |  \| |||  \| _|
 |_| |_\_|__||__||__|
+`
 
+	desc := `
 Probe - A YAML-based workflow automation tool.
 https://github.com/linyows/probe (ver: %s, rev: %s)
+`
 
+	head := `
 Usage: probe [options] <workflow-file>
 
 Arguments:
   workflow-file    Path to YAML workflow file
 
-Options:
-`
-	h = strings.TrimPrefix(h, "\n")
-	fmt.Fprintf(flag.CommandLine.Output(), h, c.ver, c.rev)
+Options:`
+
+	blue := color.New(color.FgBlue)
+	grey := color.New(color.FgHiBlack)
+
+	blue.Fprintln(flag.CommandLine.Output(), strings.TrimLeft(logo, "\n"))
+	grey.Fprintf(flag.CommandLine.Output(), strings.TrimLeft(desc, "\n"), c.ver, c.rev)
+	fmt.Fprintln(flag.CommandLine.Output(), head)
 	flag.PrintDefaults()
 }
 
@@ -139,5 +148,5 @@ func (c *Cmd) start() int {
 }
 
 func (c *Cmd) printVersion() {
-	fmt.Printf("probe version %s (commit: %s)\n", c.ver, c.rev)
+	fmt.Printf("Probe Version %s (commit: %s)\n", c.ver, c.rev)
 }

--- a/cmd/probe/cmd.go
+++ b/cmd/probe/cmd.go
@@ -42,12 +42,11 @@ func newCmd(args []string) *Cmd {
 	}
 
 	c := Cmd{
-		validFlags: []string{"help", "workflow", "rt", "verbose"},
+		validFlags: []string{"help", "rt", "verbose"},
 		ver:        version,
 		rev:        commit,
 	}
 
-	flag.StringVar(&c.WorkflowPath, "workflow", "", "Specify yaml-path of workflow")
 	flag.BoolVar(&c.Help, "help", false, "Show command usage")
 	//flag.BoolVar(&c.Init, "init", false, "Export a workflow template as yaml file")
 	//flag.BoolVar(&c.Lint, "lint", false, "Check the syntax in workflow")
@@ -63,6 +62,12 @@ func newCmd(args []string) *Cmd {
 	}
 
 	flag.Parse()
+	
+	// Set WorkflowPath from first non-flag argument
+	if flag.NArg() > 0 {
+		c.WorkflowPath = flag.Arg(0)
+	}
+	
 	return &c
 }
 
@@ -91,7 +96,10 @@ func (c *Cmd) usage() {
 Probe - A YAML-based workflow automation tool.
 https://github.com/linyows/probe (ver: %s, rev: %s)
 
-Usage: probe [options]
+Usage: probe [options] <workflow-file>
+
+Arguments:
+  workflow-file    Path to YAML workflow file
 
 Options:
 `

--- a/cmd/probe/cmd.go
+++ b/cmd/probe/cmd.go
@@ -17,6 +17,7 @@ type Cmd struct {
 	Init         bool
 	Lint         bool
 	Help         bool
+	Version      bool
 	Verbose      bool
 	RT           bool
 	validFlags   []string
@@ -42,12 +43,14 @@ func newCmd(args []string) *Cmd {
 	}
 
 	c := Cmd{
-		validFlags: []string{"help", "rt", "verbose", "v"},
+		validFlags: []string{"help", "h", "version", "rt", "verbose", "v"},
 		ver:        version,
 		rev:        commit,
 	}
 
 	flag.BoolVar(&c.Help, "help", false, "Show command usage")
+	flag.BoolVar(&c.Help, "h", false, "Show command usage (shorthand)")
+	flag.BoolVar(&c.Version, "version", false, "Show version information")
 	//flag.BoolVar(&c.Init, "init", false, "Export a workflow template as yaml file")
 	//flag.BoolVar(&c.Lint, "lint", false, "Check the syntax in workflow")
 	flag.BoolVar(&c.RT, "rt", false, "Show response time")
@@ -113,6 +116,8 @@ func (c *Cmd) start() int {
 	switch {
 	case c.Help:
 		c.usage()
+	case c.Version:
+		c.printVersion()
 	//case c.Lint:
 	//case c.Init:
 	case c.WorkflowPath == "":
@@ -131,4 +136,8 @@ func (c *Cmd) start() int {
 	}
 
 	return 1
+}
+
+func (c *Cmd) printVersion() {
+	fmt.Printf("probe version %s (commit: %s)\n", c.ver, c.rev)
 }

--- a/cmd/probe/cmd_test.go
+++ b/cmd/probe/cmd_test.go
@@ -476,7 +476,7 @@ func TestCmd_printVersion(t *testing.T) {
 	// Restore stdout
 	os.Stdout = originalStdout
 
-	expectedOutput := "probe version 1.0.0 (commit: abc123)\n"
+	expectedOutput := "Probe Version 1.0.0 (commit: abc123)\n"
 	if output != expectedOutput {
 		t.Errorf("printVersion() output = %q, want %q", output, expectedOutput)
 	}

--- a/cmd/probe/cmd_test.go
+++ b/cmd/probe/cmd_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCmd_isValid(t *testing.T) {
 	c := &Cmd{
-		validFlags: []string{"help", "workflow", "rt", "verbose"},
+		validFlags: []string{"help", "rt", "verbose"},
 	}
 
 	tests := []struct {
@@ -26,16 +26,6 @@ func TestCmd_isValid(t *testing.T) {
 		{
 			name:     "valid long flag",
 			flag:     "--help",
-			expected: true,
-		},
-		{
-			name:     "valid flag with value",
-			flag:     "--workflow=test.yml",
-			expected: true,
-		},
-		{
-			name:     "valid short flag with value",
-			flag:     "-workflow=test.yml",
 			expected: true,
 		},
 		{
@@ -94,7 +84,7 @@ func TestCmd_usage(t *testing.T) {
 		"https://github.com/linyows/probe",
 		"test-version",
 		"test-commit",
-		"Usage: probe [options]",
+		"Usage: probe [options] <workflow-file>",
 		"Options:",
 	}
 
@@ -138,8 +128,8 @@ func TestNewCmd(t *testing.T) {
 			expectRT:       false,
 		},
 		{
-			name:           "workflow flag",
-			args:           []string{"probe", "--workflow=test.yml"},
+			name:           "workflow argument",
+			args:           []string{"probe", "test.yml"},
 			expectNil:      false,
 			expectHelp:     false,
 			expectWorkflow: "test.yml",
@@ -165,8 +155,8 @@ func TestNewCmd(t *testing.T) {
 			expectRT:       true,
 		},
 		{
-			name:           "multiple flags",
-			args:           []string{"probe", "--workflow=test.yml", "--verbose", "--rt"},
+			name:           "multiple flags with workflow argument",
+			args:           []string{"probe", "--verbose", "--rt", "test.yml"},
 			expectNil:      false,
 			expectHelp:     false,
 			expectWorkflow: "test.yml",
@@ -231,7 +221,7 @@ func TestNewCmd(t *testing.T) {
 			}
 
 			// Check validFlags
-			expectedFlags := []string{"help", "workflow", "rt", "verbose"}
+			expectedFlags := []string{"help", "rt", "verbose"}
 			if len(cmd.validFlags) != len(expectedFlags) {
 				t.Errorf("newCmd(%v) validFlags length = %d, want %d", tt.args, len(cmd.validFlags), len(expectedFlags))
 			}

--- a/cmd/probe/cmd_test.go
+++ b/cmd/probe/cmd_test.go
@@ -109,7 +109,7 @@ func TestCmd_usage(t *testing.T) {
 		}
 	}
 
-	// Check ASCII art is present
+	// Check ASCII art is present (note: colors may not be in output during testing)
 	if !strings.Contains(output, "__  __  __  __  __") {
 		t.Errorf("usage() output should contain ASCII art")
 	}

--- a/cmd/probe/cmd_test.go
+++ b/cmd/probe/cmd_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCmd_isValid(t *testing.T) {
 	c := &Cmd{
-		validFlags: []string{"help", "rt", "verbose"},
+		validFlags: []string{"help", "rt", "verbose", "v"},
 	}
 
 	tests := []struct {
@@ -46,6 +46,11 @@ func TestCmd_isValid(t *testing.T) {
 		{
 			name:     "valid rt flag",
 			flag:     "--rt",
+			expected: true,
+		},
+		{
+			name:     "valid v flag (shorthand)",
+			flag:     "-v",
 			expected: true,
 		},
 	}
@@ -163,6 +168,15 @@ func TestNewCmd(t *testing.T) {
 			expectVerbose:  true,
 			expectRT:       true,
 		},
+		{
+			name:           "v shorthand flag with workflow argument",
+			args:           []string{"probe", "-v", "test.yml"},
+			expectNil:      false,
+			expectHelp:     false,
+			expectWorkflow: "test.yml",
+			expectVerbose:  true,
+			expectRT:       false,
+		},
 		// Note: Builtin command tests are commented out because they try to start actual servers
 		// In a real test environment, these would need to be mocked or tested differently
 		// {
@@ -221,7 +235,7 @@ func TestNewCmd(t *testing.T) {
 			}
 
 			// Check validFlags
-			expectedFlags := []string{"help", "rt", "verbose"}
+			expectedFlags := []string{"help", "rt", "verbose", "v"}
 			if len(cmd.validFlags) != len(expectedFlags) {
 				t.Errorf("newCmd(%v) validFlags length = %d, want %d", tt.args, len(cmd.validFlags), len(expectedFlags))
 			}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -25,7 +25,7 @@ func TestEndToEndExitCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := exec.Command("go", "run", "./cmd/probe", "--workflow", tt.workflowPath)
+			cmd := exec.Command("go", "run", "./cmd/probe", tt.workflowPath)
 			output, err := cmd.CombinedOutput()
 			t.Logf("Command output: %s", string(output))
 


### PR DESCRIPTION
Modified CLI interface to accept workflow file as a positional argument
instead of using --workflow flag for better UX:

- Updated cmd.go to parse workflow path from first non-flag argument
- Removed --workflow from validFlags list
- Updated usage text to show new argument format
- Fixed cmd_test.go to reflect the new argument parsing
- Updated e2e_test.go to use positional argument format

Usage changed from:
  probe --workflow <file>
to:
  probe <workflow-file>