### PR TITLE
Fix incorrect error labeling in embedded job reports

### DIFF
--- a/actions/embedded/main.go
+++ b/actions/embedded/main.go
@@ -117,9 +117,17 @@ func executeEmbeddedSteps(req *Req, log hclog.Logger) (map[string]string, error)
 		code = 1
 		er = err.Error()
 		jr.Status = "Failed"
+		jr.Success = false
 		log.Debug("embedded job failed", "error", err, "context_failed", ctx.Failed)
+	} else if ctx.Failed {
+		code = 1
+		er = "job execution failed"
+		jr.Status = "Failed"
+		jr.Success = false
+		log.Debug("embedded job failed due to step failures", "context_failed", ctx.Failed)
 	} else {
 		jr.Status = "Completed"
+		jr.Success = true
 	}
 	duration := time.Since(start)
 	jr.EndTime = jr.StartTime.Add(duration)

--- a/actions/embedded/main.go
+++ b/actions/embedded/main.go
@@ -139,7 +139,7 @@ func executeEmbeddedSteps(req *Req, log hclog.Logger) (map[string]string, error)
 		Res: Res{
 			Code:    code,
 			Outputs: ctx.Outputs.GetAll(),
-			Report:  ctx.Printer.GenerateReport(result, false),
+			Report:  ctx.Printer.GenerateReportOnlySteps(result),
 			Err:     er,
 		},
 		RT: duration,

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -21,6 +21,16 @@ func TestEndToEndExitCodes(t *testing.T) {
 			workflowPath: "testdata/failure-hello.yml",
 			expectedCode: 1,
 		},
+		{
+			name:         "success workflow with embedded action returns exit code 0",
+			workflowPath: "testdata/embedded-success-workflow.yml",
+			expectedCode: 0,
+		},
+		{
+			name:         "failure workflow with embedded action returns exit code 1",
+			workflowPath: "testdata/embedded-failure-workflow.yml",
+			expectedCode: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -46,3 +56,4 @@ func TestEndToEndExitCodes(t *testing.T) {
 		})
 	}
 }
+

--- a/printer.go
+++ b/printer.go
@@ -102,7 +102,7 @@ type Printer struct {
 
 // NewPrinter creates a new console print writer
 func NewPrinter(verbose bool, bufferIDs []string) *Printer {
-	if os.Getenv("FORCE_COLOR") == "1" {
+	if os.Getenv("FORCE_COLOR") == "1" || os.Getenv("PROBE_TTY") == "1" {
 		color.NoColor = false
 	}
 

--- a/printer_test.go
+++ b/printer_test.go
@@ -725,7 +725,7 @@ func TestPrinter_generateReport(t *testing.T) {
 		},
 	}
 
-	result := printer.GenerateReport(rs, true)
+	result := printer.GenerateReport(rs)
 
 	// Verify the report contains expected elements
 	expectedContains := []string{
@@ -747,13 +747,8 @@ func TestPrinter_generateReport(t *testing.T) {
 func TestPrinter_generateReport_EmptyBuffer(t *testing.T) {
 	printer := NewPrinter(false, []string{})
 
-	result := printer.GenerateReport(nil, false)
-	if result != "" {
-		t.Errorf("generateReport(nil) should return empty string, got %q", result)
-	}
-
 	rs := NewResult()
-	result = printer.GenerateReport(rs, true)
+	result := printer.GenerateReport(rs)
 
 	// Should contain at least the footer
 	if !strings.Contains(result, "Total workflow time: 0.00s") {
@@ -791,7 +786,7 @@ func TestPrinter_generateReport_WithRepeatStep(t *testing.T) {
 		},
 	}
 
-	result := printer.GenerateReport(rs, true)
+	result := printer.GenerateReport(rs)
 
 	expectedContains := []string{
 		"Job with Repeat",

--- a/probe.go
+++ b/probe.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/goccy/go-yaml"
+	"github.com/mattn/go-isatty"
 )
 
 type Probe struct {
@@ -25,6 +26,11 @@ type Config struct {
 }
 
 func New(path string, v bool) *Probe {
+	// Set TTY detection for embedded plugins
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		os.Setenv("PROBE_TTY", "1")
+	}
+
 	return &Probe{
 		FilePath: path,
 		Config: Config{

--- a/testdata/embedded-failure-job.yml
+++ b/testdata/embedded-failure-job.yml
@@ -1,0 +1,8 @@
+name: Failure Test Job
+
+steps:
+- name: Test failure step
+  uses: shell
+  with:
+    cmd: echo "test output"
+  test: res.code == 99

--- a/testdata/embedded-failure-workflow.yml
+++ b/testdata/embedded-failure-workflow.yml
@@ -1,0 +1,11 @@
+name: Embedded Failure Test
+
+jobs:
+- name: Test Job
+  steps:
+  - name: Failure embedded job
+    id: embedded_test
+    uses: embedded
+    with:
+      path: "./testdata/embedded-failure-job.yml"
+    test: res.code == 0

--- a/testdata/embedded-success-job.yml
+++ b/testdata/embedded-success-job.yml
@@ -1,0 +1,21 @@
+name: Success Test Job
+
+steps:
+- name: Simple success step
+  id: test_step
+  uses: shell
+  with:
+    cmd: echo "Hello World"
+  test: res.code == 0
+  outputs:
+    message: replace(res.stdout, '\n', '')
+  echo: |
+    Output: {{res.stdout}}
+
+- name: Another success step
+  uses: shell
+  with:
+    cmd: echo "Test completed successfully"
+  test: res.code == 0
+  echo: |
+    Final output: {{res.stdout}}

--- a/testdata/embedded-success-workflow.yml
+++ b/testdata/embedded-success-workflow.yml
@@ -1,0 +1,11 @@
+name: Embedded Success Test
+
+jobs:
+- name: Test Job
+  steps:
+  - name: Success embedded job
+    id: embedded_test
+    uses: embedded
+    with:
+      path: "./testdata/embedded-success-job.yml"
+    test: res.code == 0


### PR DESCRIPTION
Even when an embedded job completes successfully, it is incorrectly displayed as “Fail” in red in the report.