### PR TITLE
Fix embedded job report formatting to prevent display corruption

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -406,7 +406,7 @@ func (p *Printer) generateJobResultsFromStepResults(stepResults []StepResult) st
 				a5space := "     "
 				re := strings.ReplaceAll(stepResult.Report, "\n", "\n"+a5space)
 				re = strings.TrimRight(re, " \n\t\r")
-				output.WriteString(a5space + re)
+				output.WriteString(a5space + re + "\n")
 			}
 
 			if stepResult.EchoOutput != "" {


### PR DESCRIPTION
## Summary
- Fix missing newline after embedded job reports that caused display corruption
- Add comprehensive test coverage to prevent regression of this formatting issue

## Details
When embedded jobs generate reports, the output was missing a trailing newline which caused the report text to merge with subsequent output, resulting in corrupted display formatting. This was fixed by adding `+ "\n"` to ensure proper line separation.

## Test plan
- [x] Added `TestPrinter_generateJobResultsFromStepResults_ReportNewlineFormatting` test
- [x] Test covers single line reports, multiline reports, trailing whitespace handling
- [x] Test verifies proper indentation (5 spaces) and newline termination
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)