### PR TITLE
Fix shell background execution with proper process isolation

### DIFF
--- a/shell/client.go
+++ b/shell/client.go
@@ -237,15 +237,15 @@ func (r *Req) Do() (*Result, error) {
 
 		// Start command
 		if err := cmd.Start(); err != nil {
-			logFile.Close()
-			os.Remove(logPath)
+			_ = logFile.Close()
+			_ = os.Remove(logPath)
 			return result, fmt.Errorf("failed to start command: %w", err)
 		}
 
 		// Start a goroutine to close the log file when process exits
 		go func() {
-			cmd.Wait()
-			logFile.Close()
+			_ = cmd.Wait()
+			_ = logFile.Close()
 		}()
 
 		result.RT = time.Since(start)


### PR DESCRIPTION
## Summary
- Fix shell background execution to achieve proper process isolation using setsid
- Resolve issue where background processes were terminated when parent Go process exits
- Implement proper log file output for background processes

## Changes
- **Process Isolation**: Added `SysProcAttr.Setsid: true` to create new session for background processes
- **Context Management**: Use `context.Background()` instead of `context.WithTimeout()` for background execution to prevent timeout-based termination
- **Log Output**: Redirect stdout/stderr to log files named `bg-cmd-<hash>.log` using MD5 hash of command
- **Cross-platform**: Windows-safe implementation with runtime OS checking

## Test Plan
- [x] All existing tests pass
- [x] Background processes survive parent process termination
- [x] Log files are created with proper naming convention
- [x] Process isolation works correctly on Unix-like systems

🤖 Generated with [Claude Code](https://claude.ai/code)