### PR TITLE
Support relative paths for shell action workdir parameter

### DIFF
--- a/shell/client.go
+++ b/shell/client.go
@@ -136,14 +136,15 @@ func validateShellPath(shell string) error {
 }
 
 func validateWorkdir(workdir string) error {
-	// Check if path is absolute
-	if !filepath.IsAbs(workdir) {
-		return fmt.Errorf("workdir must be an absolute path: %s", workdir)
+	// Convert relative path to absolute path
+	absPath, err := filepath.Abs(workdir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve workdir path: %s", err)
 	}
 
 	// Check if directory exists
-	if _, err := os.Stat(workdir); os.IsNotExist(err) {
-		return fmt.Errorf("workdir does not exist: %s", workdir)
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return fmt.Errorf("workdir does not exist: %s", absPath)
 	}
 
 	return nil
@@ -193,7 +194,8 @@ func (r *Req) Do() (*Result, error) {
 
 	// Set working directory
 	if params.workdir != "" {
-		cmd.Dir = params.workdir
+		absWorkdir, _ := filepath.Abs(params.workdir)
+		cmd.Dir = absWorkdir
 	}
 
 	// Set environment variables


### PR DESCRIPTION
## Summary

- Allow relative paths for the `workdir` parameter in shell actions
- Modified `validateWorkdir()` function to convert relative paths to absolute paths using `filepath.Abs()`
- Updated command execution to ensure working directory is set with absolute path
- Added comprehensive test coverage for relative path validation and execution

## Changes Made

### Core Changes
- `shell/client.go:139-151`: Modified `validateWorkdir()` to accept and resolve relative paths
- `shell/client.go:197-200`: Updated command execution to use absolute paths for working directory

### Test Coverage
- Added `TestValidateWorkdir()` with test cases for both absolute and relative paths
- Added integration test case for command execution with relative workdir
- Updated existing test expectations to handle different command types

## Test Plan

- [x] All existing tests pass
- [x] New validation tests cover relative path scenarios
- [x] Integration test verifies `pwd` command works correctly with relative workdir
- [x] Backward compatibility maintained for absolute paths

## Backward Compatibility

This change is fully backward compatible. Existing workflows using absolute paths will continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)