### PR TITLE
feat: template support for wait field, improved plugin error handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,11 @@ jobs:
         wait-on:
           http-get://localhost:8080/status/200
 
-    - name: Run shell.yml by custom action
-      uses: linyows/probe-action@v1
-      with:
-        paths: |
-          examples/realtime-print.yml
-          examples/embedded-job.yml
+    - name: Run shell.yml by local probe binary
+      env:
+        FORCE_COLOR: '1'
+        TERM: xterm-256color
+      run: |
+        make
+        ./probe examples/realtime-print.yml
+        ./probe examples/embedded-job.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,11 +49,9 @@ jobs:
         wait-on:
           http-get://localhost:8080/status/200
 
-    - name: Run shell.yml by local probe binary
-      env:
-        FORCE_COLOR: '1'
-        TERM: xterm-256color
-      run: |
-        make
-        ./probe examples/realtime-print.yml
-        ./probe examples/embedded-job.yml
+    - name: Run shell.yml by custom action
+      uses: linyows/probe-action@v1
+      with:
+        paths: |
+          examples/realtime-print.yml
+          examples/embedded-job.yml

--- a/actions/hello/main.go
+++ b/actions/hello/main.go
@@ -20,7 +20,7 @@ func (a *Action) Run(args []string, with map[string]any) (map[string]any, error)
 	for k, v := range with {
 		res[k] = v
 	}
-	res["status"] = 0 // Always success for hello action (ExitStatusSuccess)
+	res["status"] = 0   // Always success for hello action (ExitStatusSuccess)
 	res["dump"] = false // Don't dump request/response for hello action
 
 	// Return in expected structure

--- a/actions/hello/main.go
+++ b/actions/hello/main.go
@@ -15,12 +15,21 @@ type Action struct {
 func (a *Action) Run(args []string, with map[string]any) (map[string]any, error) {
 	a.log.Info("Hello!")
 
-	// Add status field (hello action always succeeds)
-	result := make(map[string]any)
+	// Create response data
+	res := make(map[string]any)
 	for k, v := range with {
-		result[k] = v
+		res[k] = v
 	}
-	result["status"] = 0 // Always success for hello action (ExitStatusSuccess)
+	res["status"] = 0 // Always success for hello action (ExitStatusSuccess)
+	res["dump"] = false // Don't dump request/response for hello action
+
+	// Return in expected structure
+	result := map[string]any{
+		"req":    with,
+		"res":    res,
+		"rt":     "",
+		"status": 0,
+	}
 
 	return result, nil
 }

--- a/embedded/client.go
+++ b/embedded/client.go
@@ -121,8 +121,8 @@ func (r *Req) Do() (*Result, error) {
 
 	// Only return error for system-level failures (file not found, parsing errors, etc.)
 	// Test failures should not be treated as plugin errors
-	if !success && errorMsg != "" && 
-		errorMsg != "job execution failed" && 
+	if !success && errorMsg != "" &&
+		errorMsg != "job execution failed" &&
 		!strings.Contains(errorMsg, "execution error in job_start: job execution failed") {
 		detailedError := fmt.Sprintf("embedded job execution failed: %s", errorMsg)
 		if report != "" {

--- a/examples/jobs/dev.yml
+++ b/examples/jobs/dev.yml
@@ -44,4 +44,3 @@ steps:
   test: res.code == 200
   echo: |
     Response Body: {{res.body}}
-  test: res.code == 200

--- a/expr.go
+++ b/expr.go
@@ -159,7 +159,7 @@ func (e *Expr) Options(env any) []ex.Option {
 				if len(params) != 1 {
 					return nil, fmt.Errorf("parse_int requires exactly 1 parameter")
 				}
-				
+
 				switch v := params[0].(type) {
 				case string:
 					i, err := strconv.ParseInt(v, 10, 64)
@@ -429,11 +429,11 @@ func isWholeStringTemplate(input string) bool {
 	if !strings.HasPrefix(trimmed, templateStart) || !strings.HasSuffix(trimmed, templateEnd) {
 		return false
 	}
-	
+
 	// Count template markers to ensure there's exactly one pair
 	startCount := strings.Count(trimmed, templateStart)
 	endCount := strings.Count(trimmed, templateEnd)
-	
+
 	return startCount == 1 && endCount == 1
 }
 
@@ -443,7 +443,7 @@ func extractTemplateExpression(input string) string {
 	if !strings.HasPrefix(trimmed, templateStart) || !strings.HasSuffix(trimmed, templateEnd) {
 		return ""
 	}
-	
+
 	// Remove template markers and trim whitespace
 	expression := trimmed[len(templateStart) : len(trimmed)-len(templateEnd)]
 	return strings.TrimSpace(expression)
@@ -519,7 +519,7 @@ func (e *Expr) EvalTemplateWithTypePreservation(input string, env any) (any, err
 		if expression == "" {
 			return "", fmt.Errorf("failed to extract expression from template: %s", input)
 		}
-		
+
 		// Use Eval directly to preserve type
 		return e.Eval(expression, env)
 	}

--- a/expr_test.go
+++ b/expr_test.go
@@ -360,19 +360,19 @@ func TestCustomFunctions(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				result, err := expr.Eval(tt.input, tt.env)
-				
+
 				if tt.wantErr {
 					if err == nil {
 						t.Errorf("expected error but got none")
 					}
 					return
 				}
-				
+
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 					return
 				}
-				
+
 				if result != tt.expected {
 					t.Errorf("expected %v, got %v", tt.expected, result)
 				}
@@ -383,7 +383,7 @@ func TestCustomFunctions(t *testing.T) {
 
 func TestWholeStringTemplateTypePreservation(t *testing.T) {
 	expr := &Expr{}
-	
+
 	t.Run("integer type preservation", func(t *testing.T) {
 		result, err := expr.EvalTemplateWithTypePreservation("{{ vars.count }}", map[string]any{
 			"vars": map[string]any{"count": 123},
@@ -520,20 +520,20 @@ func TestHelperFunctions(t *testing.T) {
 
 func TestEvalTemplateMapTypePreservation(t *testing.T) {
 	expr := &Expr{}
-	
+
 	input := map[string]any{
-		"number":       "{{ vars.count }}",
-		"price":        "{{ vars.price }}",
-		"enabled":      "{{ vars.enabled }}",
-		"message":      "{{ vars.message }}",
-		"partial":      "Count: {{ vars.count }}",
-		"multiple":     "{{ vars.name }} is {{ vars.age }}",
-		"unchanged":    "static value",
+		"number":    "{{ vars.count }}",
+		"price":     "{{ vars.price }}",
+		"enabled":   "{{ vars.enabled }}",
+		"message":   "{{ vars.message }}",
+		"partial":   "Count: {{ vars.count }}",
+		"multiple":  "{{ vars.name }} is {{ vars.age }}",
+		"unchanged": "static value",
 		"nested": map[string]any{
 			"inner_number": "{{ vars.inner }}",
 		},
 	}
-	
+
 	env := map[string]any{
 		"vars": map[string]any{
 			"count":   123,
@@ -545,9 +545,9 @@ func TestEvalTemplateMapTypePreservation(t *testing.T) {
 			"inner":   456,
 		},
 	}
-	
+
 	result := expr.EvalTemplateMap(input, env)
-	
+
 	// Check type preservation
 	if result["number"] != 123 {
 		t.Errorf("number: expected 123 (int), got %v (%T)", result["number"], result["number"])
@@ -561,7 +561,7 @@ func TestEvalTemplateMapTypePreservation(t *testing.T) {
 	if result["message"] != "hello" {
 		t.Errorf("message: expected \"hello\" (string), got %v (%T)", result["message"], result["message"])
 	}
-	
+
 	// Check string templates remain string
 	if result["partial"] != "Count: 123" {
 		t.Errorf("partial: expected \"Count: 123\", got %v", result["partial"])
@@ -569,12 +569,12 @@ func TestEvalTemplateMapTypePreservation(t *testing.T) {
 	if result["multiple"] != "John is 30" {
 		t.Errorf("multiple: expected \"John is 30\", got %v", result["multiple"])
 	}
-	
+
 	// Check unchanged values
 	if result["unchanged"] != "static value" {
 		t.Errorf("unchanged: expected \"static value\", got %v", result["unchanged"])
 	}
-	
+
 	// Check nested maps
 	nested, ok := result["nested"].(map[string]any)
 	if !ok {

--- a/mapping.go
+++ b/mapping.go
@@ -282,7 +282,7 @@ func MapToStructByTags(params map[string]any, dest any) error {
 						// Type-safe assignment based on field type
 						fieldType := field.Type()
 						valueType := reflect.TypeOf(v)
-						
+
 						if valueType == fieldType {
 							// Direct assignment if types match
 							field.Set(reflect.ValueOf(v))

--- a/printer.go
+++ b/printer.go
@@ -539,7 +539,7 @@ func (p *Printer) generateTestFailure(testExpr string, result interface{}, req, 
 			}
 		}
 	}
-	
+
 	output := fmt.Sprintf("       %s %#v\n", colorInfo().Sprintf("request:"), req)
 	output += fmt.Sprintf("       %s %#v\n", colorInfo().Sprintf("response:"), res)
 	return output

--- a/printer.go
+++ b/printer.go
@@ -531,6 +531,15 @@ func (p *Printer) generateEchoOutput(content string, err error) string {
 
 // generateTestFailure formats test failure output with request/response info
 func (p *Printer) generateTestFailure(testExpr string, result interface{}, req, res map[string]any) string {
+	// Check if response has dump field set to false
+	if res != nil {
+		if dump, exists := res["dump"]; exists {
+			if dumpBool, ok := dump.(bool); ok && !dumpBool {
+				return "" // Don't dump request/response if dump is false
+			}
+		}
+	}
+	
 	output := fmt.Sprintf("       %s %#v\n", colorInfo().Sprintf("request:"), req)
 	output += fmt.Sprintf("       %s %#v\n", colorInfo().Sprintf("response:"), res)
 	return output

--- a/shell/client.go
+++ b/shell/client.go
@@ -257,12 +257,12 @@ func (r *Req) Do() (*Result, error) {
 			Log:    logPath,
 		}
 		result.Status = -1 // Indicate background execution
-		
+
 		// callback after
 		if r.cb != nil && r.cb.after != nil {
 			r.cb.after(result)
 		}
-		
+
 		return result, nil
 	}
 

--- a/step.go
+++ b/step.go
@@ -465,7 +465,7 @@ func (st *Step) handleWait(jCtx *JobContext) {
 	if st.Wait == "" {
 		return
 	}
-	
+
 	// Evaluate wait expression template first
 	waitExpr, err := st.Expr.EvalTemplate(st.Wait, st.ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add template expression support for step wait field
- Improve embedded job error handling and reporting
- Add dump field control for plugin request/response output

## Changes

### 1. Template Support for Wait Field
- Enable template evaluation in `wait` field to support dynamic wait times
- Added template evaluation in `handleWait()` before parsing duration
- Updated `getWaitTimeForDisplay()` to handle template expressions
- Gracefully handle template evaluation errors during result creation

Usage example:
```yaml
steps:
  - name: Dynamic wait
    uses: hello
    vars:
      seconds: 5
    wait: "{{vars.seconds}}s"
```

### 2. Improved Embedded Job Error Handling
- Distinguish between system errors and test failures
- Only return plugin errors for system-level failures, not test failures
- Include detailed job report in error messages for better debugging
- Added Dump field to control request/response dumping

### 3. Plugin Response Dump Control
- Added `dump` field check in `generateTestFailure()`
- Plugins can now control whether their request/response is dumped
- Updated hello plugin to include `dump: false` in response structure
- Prevents verbose output for plugins that don't need detailed debugging

## Test plan
- [x] Verify hardcoded wait values work correctly
- [x] Test template expressions in wait field
- [x] Confirm embedded job failures show proper error messages
- [x] Validate dump field controls request/response output
- [x] Ensure existing functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)