### PR TITLE
Add mail-latency action to analyze email latency from headers

### DIFF
--- a/actions/mail-latency/main.go
+++ b/actions/mail-latency/main.go
@@ -1,0 +1,99 @@
+package maillatency
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin"
+	"github.com/linyows/probe"
+	"github.com/linyows/probe/mail"
+)
+
+type Action struct {
+	log hclog.Logger
+}
+
+func (a *Action) Run(args []string, with map[string]any) (map[string]any, error) {
+	// Validate that required parameters are provided
+	if len(with) == 0 {
+		return map[string]any{}, errors.New("mail-latency action requires parameters in 'with' section. Please specify 'mail_dir' and 'output_dir' parameters")
+	}
+
+	mailDir, ok := with["mail_dir"].(string)
+	if !ok || mailDir == "" {
+		return map[string]any{}, errors.New("mail-latency action requires 'mail_dir' parameter in 'with' section")
+	}
+
+	// Get required output_dir parameter
+	outputDir, ok := with["output_dir"].(string)
+	if !ok || outputDir == "" {
+		return map[string]any{}, errors.New("mail-latency action requires 'output_dir' parameter in 'with' section")
+	}
+
+	a.log.Debug("received mail-latency request", "mail_dir", mailDir, "output_dir", outputDir)
+
+	// Create a buffer to capture CSV output
+	var csvBuffer bytes.Buffer
+
+	// Measure execution time
+	start := time.Now()
+	// Get latencies and write to buffer
+	if err := mail.GetLatencies(mailDir, &csvBuffer); err != nil {
+		a.log.Error("mail-latency request failed", "error", err)
+		return map[string]any{}, err
+	}
+	rt := time.Since(start)
+
+	csvContent := csvBuffer.String()
+
+	// Generate filename with timestamp
+	timestamp := time.Now().Format("20060102-150405")
+	filename := "mail-latency." + timestamp + ".csv"
+	outputFile := outputDir + "/" + filename
+
+	// Write to file
+	if err := os.WriteFile(outputFile, []byte(csvContent), 0644); err != nil {
+		a.log.Error("failed to write output file", "error", err, "file", outputFile)
+		return map[string]any{}, err
+	}
+	a.log.Debug("CSV written to file", "file", outputFile)
+
+	a.log.Debug("mail-latency request completed successfully", "rt", rt)
+
+	// Create response data
+	res := map[string]any{
+		"output_file": outputFile,
+		"status":      0,
+	}
+
+	// Return in expected structure
+	result := map[string]any{
+		"req":    with,
+		"res":    res,
+		"rt":     rt.String(),
+		"status": 0,
+	}
+
+	return result, nil
+}
+
+func Serve() {
+	log := hclog.New(&hclog.LoggerOptions{
+		Level:      hclog.Debug,
+		Output:     os.Stderr,
+		JSONFormat: true,
+	})
+
+	pl := &probe.ActionsPlugin{
+		Impl: &Action{log: log},
+	}
+
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: probe.Handshake,
+		Plugins:         map[string]plugin.Plugin{"actions": pl},
+		GRPCServer:      plugin.DefaultGRPCServer,
+	})
+}

--- a/cmd/probe/main.go
+++ b/cmd/probe/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/linyows/probe/actions/hello"
 	http "github.com/linyows/probe/actions/http"
 	imapaction "github.com/linyows/probe/actions/imap"
+	maillatencyaction "github.com/linyows/probe/actions/mail-latency"
 	"github.com/linyows/probe/actions/shell"
 	"github.com/linyows/probe/actions/smtp"
 	sshaction "github.com/linyows/probe/actions/ssh"
@@ -278,6 +279,10 @@ func (c *Cmd) runBuiltinActions(name string) {
 	case "imap":
 		if !c.mocking {
 			imapaction.Serve()
+		}
+	case "mail-latency":
+		if !c.mocking {
+			maillatencyaction.Serve()
 		}
 
 	default:

--- a/examples/mail-latency.yml
+++ b/examples/mail-latency.yml
@@ -1,0 +1,11 @@
+name: Mail Latency Workflow
+description: Test workflow for mail-latency action
+jobs:
+- name: mail-latency-job
+  steps:
+  - name: Mail Latency Analysis
+    uses: mail-latency
+    with:
+      mail_dir: "mail/testdata/mail"
+      output_dir: "/tmp"
+    test: res.status == 0 && res.output_file != ""


### PR DESCRIPTION
## Summary
This PR adds a new `mail-latency` action that analyzes email headers to calculate latency metrics and outputs results to CSV.

## Features
- Analyzes mail headers to extract send/receive timestamps
- Calculates elapsed time, end-to-end latency, and relay latency
- Outputs CSV with comprehensive latency metrics
- Auto-generates timestamped filename: `mail-latency.YYYYMMDD-HHmmss.csv`
- Returns execution time (rt) for performance monitoring

## Usage
```yaml
- name: Mail Latency Analysis
  uses: mail-latency
  with:
    mail_dir: "path/to/mail/directory"
    output_dir: "/path/to/output"
  test: res.status == 0 && res.output_file != ""
```

## Response Structure
```go
res := {
    "output_file": "/path/to/output/mail-latency.20251005-205148.csv",
    "status":      0
}
```

## CSV Output Columns
- Elapsed Time (sec) - To Sent Time
- Elapsed Time (sec) - To Received Time
- Sent Time
- Last Received Time
- End-to-End Latency (sec)
- First Received Time
- Relay Latency (sec)
- Return Path
- File Path

## Test plan
- [x] Built successfully
- [x] All existing tests pass
- [x] Tested with example workflow in `examples/mail-latency.yml`
- [x] Verified CSV output format and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)