### PR TITLE
Add environment variable override for repeat and retry limits

### DIFF
--- a/actions_test.go
+++ b/actions_test.go
@@ -261,6 +261,7 @@ func TestActionsServer_Run(t *testing.T) {
 
 			if resp == nil {
 				t.Fatal("response should not be nil")
+				return
 			}
 
 			// Convert result back to map for comparison

--- a/repeat.go
+++ b/repeat.go
@@ -106,7 +106,8 @@ type Repeat struct {
 func (r *Repeat) Validate() error {
 	maxCount := getMaxRepeatCount()
 	if r.Count >= maxCount {
-		return fmt.Errorf("repeat count %d exceeds maximum allowed value %d (set via %s environment variable)", r.Count, maxCount, EnvMaxRepeatCount)
+		return fmt.Errorf("repeat count %d exceeds maximum allowed value of %d. To allow higher values, set %s environment variable (e.g., %s=%d)",
+			r.Count, maxCount, EnvMaxRepeatCount, EnvMaxRepeatCount, r.Count+1)
 	}
 	return nil
 }
@@ -122,7 +123,8 @@ type StepRetry struct {
 func (s *StepRetry) Validate() error {
 	maxAttempts := getMaxAttempts()
 	if s.MaxAttempts > maxAttempts {
-		return fmt.Errorf("max_attempts %d exceeds maximum allowed value %d (set via %s environment variable)", s.MaxAttempts, maxAttempts, EnvMaxAttempts)
+		return fmt.Errorf("max_attempts %d exceeds maximum allowed value of %d. To allow higher values, set %s environment variable (e.g., %s=%d)",
+			s.MaxAttempts, maxAttempts, EnvMaxAttempts, EnvMaxAttempts, s.MaxAttempts)
 	}
 	return nil
 }

--- a/repeat_test.go
+++ b/repeat_test.go
@@ -453,7 +453,7 @@ func TestRepeatFunctionality_EdgeCases(t *testing.T) {
 func TestEnvironmentVariableOverride(t *testing.T) {
 	t.Run("default max repeat count", func(t *testing.T) {
 		// Ensure environment variable is not set
-		os.Unsetenv(EnvMaxRepeatCount)
+		_ = os.Unsetenv(EnvMaxRepeatCount)
 
 		max := getMaxRepeatCount()
 		if max != DefaultMaxRepeatCount {
@@ -464,8 +464,10 @@ func TestEnvironmentVariableOverride(t *testing.T) {
 	t.Run("custom max repeat count via env", func(t *testing.T) {
 		// Set custom max via environment variable
 		customMax := 50000
-		os.Setenv(EnvMaxRepeatCount, fmt.Sprintf("%d", customMax))
-		defer os.Unsetenv(EnvMaxRepeatCount)
+		if err := os.Setenv(EnvMaxRepeatCount, fmt.Sprintf("%d", customMax)); err != nil {
+			t.Fatalf("Failed to set environment variable: %v", err)
+		}
+		defer func() { _ = os.Unsetenv(EnvMaxRepeatCount) }()
 
 		max := getMaxRepeatCount()
 		if max != customMax {
@@ -475,7 +477,7 @@ func TestEnvironmentVariableOverride(t *testing.T) {
 
 	t.Run("default max attempts", func(t *testing.T) {
 		// Ensure environment variable is not set
-		os.Unsetenv(EnvMaxAttempts)
+		_ = os.Unsetenv(EnvMaxAttempts)
 
 		max := getMaxAttempts()
 		if max != DefaultMaxAttempts {
@@ -486,8 +488,10 @@ func TestEnvironmentVariableOverride(t *testing.T) {
 	t.Run("custom max attempts via env", func(t *testing.T) {
 		// Set custom max via environment variable
 		customMax := 25000
-		os.Setenv(EnvMaxAttempts, fmt.Sprintf("%d", customMax))
-		defer os.Unsetenv(EnvMaxAttempts)
+		if err := os.Setenv(EnvMaxAttempts, fmt.Sprintf("%d", customMax)); err != nil {
+			t.Fatalf("Failed to set environment variable: %v", err)
+		}
+		defer func() { _ = os.Unsetenv(EnvMaxAttempts) }()
 
 		max := getMaxAttempts()
 		if max != customMax {
@@ -497,8 +501,10 @@ func TestEnvironmentVariableOverride(t *testing.T) {
 
 	t.Run("invalid env value falls back to default", func(t *testing.T) {
 		// Set invalid value
-		os.Setenv(EnvMaxRepeatCount, "invalid")
-		defer os.Unsetenv(EnvMaxRepeatCount)
+		if err := os.Setenv(EnvMaxRepeatCount, "invalid"); err != nil {
+			t.Fatalf("Failed to set environment variable: %v", err)
+		}
+		defer func() { _ = os.Unsetenv(EnvMaxRepeatCount) }()
 
 		max := getMaxRepeatCount()
 		if max != DefaultMaxRepeatCount {
@@ -508,8 +514,10 @@ func TestEnvironmentVariableOverride(t *testing.T) {
 
 	t.Run("negative env value falls back to default", func(t *testing.T) {
 		// Set negative value
-		os.Setenv(EnvMaxRepeatCount, "-100")
-		defer os.Unsetenv(EnvMaxRepeatCount)
+		if err := os.Setenv(EnvMaxRepeatCount, "-100"); err != nil {
+			t.Fatalf("Failed to set environment variable: %v", err)
+		}
+		defer func() { _ = os.Unsetenv(EnvMaxRepeatCount) }()
 
 		max := getMaxRepeatCount()
 		if max != DefaultMaxRepeatCount {
@@ -520,7 +528,7 @@ func TestEnvironmentVariableOverride(t *testing.T) {
 
 func TestRepeatValidation(t *testing.T) {
 	t.Run("valid repeat count", func(t *testing.T) {
-		os.Unsetenv(EnvMaxRepeatCount)
+		_ = os.Unsetenv(EnvMaxRepeatCount)
 
 		r := &Repeat{Count: 100}
 		err := r.Validate()
@@ -530,7 +538,7 @@ func TestRepeatValidation(t *testing.T) {
 	})
 
 	t.Run("repeat count at default limit", func(t *testing.T) {
-		os.Unsetenv(EnvMaxRepeatCount)
+		_ = os.Unsetenv(EnvMaxRepeatCount)
 
 		r := &Repeat{Count: DefaultMaxRepeatCount}
 		err := r.Validate()
@@ -540,7 +548,7 @@ func TestRepeatValidation(t *testing.T) {
 	})
 
 	t.Run("repeat count exceeds default limit", func(t *testing.T) {
-		os.Unsetenv(EnvMaxRepeatCount)
+		_ = os.Unsetenv(EnvMaxRepeatCount)
 
 		r := &Repeat{Count: DefaultMaxRepeatCount + 1}
 		err := r.Validate()
@@ -551,8 +559,10 @@ func TestRepeatValidation(t *testing.T) {
 
 	t.Run("repeat count valid with custom limit", func(t *testing.T) {
 		customMax := 50000
-		os.Setenv(EnvMaxRepeatCount, fmt.Sprintf("%d", customMax))
-		defer os.Unsetenv(EnvMaxRepeatCount)
+		if err := os.Setenv(EnvMaxRepeatCount, fmt.Sprintf("%d", customMax)); err != nil {
+			t.Fatalf("Failed to set environment variable: %v", err)
+		}
+		defer func() { _ = os.Unsetenv(EnvMaxRepeatCount) }()
 
 		r := &Repeat{Count: 20000}
 		err := r.Validate()
@@ -563,8 +573,10 @@ func TestRepeatValidation(t *testing.T) {
 
 	t.Run("repeat count exceeds custom limit", func(t *testing.T) {
 		customMax := 50000
-		os.Setenv(EnvMaxRepeatCount, fmt.Sprintf("%d", customMax))
-		defer os.Unsetenv(EnvMaxRepeatCount)
+		if err := os.Setenv(EnvMaxRepeatCount, fmt.Sprintf("%d", customMax)); err != nil {
+			t.Fatalf("Failed to set environment variable: %v", err)
+		}
+		defer func() { _ = os.Unsetenv(EnvMaxRepeatCount) }()
 
 		r := &Repeat{Count: customMax}
 		err := r.Validate()
@@ -576,7 +588,7 @@ func TestRepeatValidation(t *testing.T) {
 
 func TestStepRetryValidation(t *testing.T) {
 	t.Run("valid max attempts", func(t *testing.T) {
-		os.Unsetenv(EnvMaxAttempts)
+		_ = os.Unsetenv(EnvMaxAttempts)
 
 		s := &StepRetry{MaxAttempts: 100}
 		err := s.Validate()
@@ -586,7 +598,7 @@ func TestStepRetryValidation(t *testing.T) {
 	})
 
 	t.Run("max attempts at default limit", func(t *testing.T) {
-		os.Unsetenv(EnvMaxAttempts)
+		_ = os.Unsetenv(EnvMaxAttempts)
 
 		s := &StepRetry{MaxAttempts: DefaultMaxAttempts}
 		err := s.Validate()
@@ -596,7 +608,7 @@ func TestStepRetryValidation(t *testing.T) {
 	})
 
 	t.Run("max attempts exceeds default limit", func(t *testing.T) {
-		os.Unsetenv(EnvMaxAttempts)
+		_ = os.Unsetenv(EnvMaxAttempts)
 
 		s := &StepRetry{MaxAttempts: DefaultMaxAttempts + 1}
 		err := s.Validate()
@@ -607,8 +619,10 @@ func TestStepRetryValidation(t *testing.T) {
 
 	t.Run("max attempts valid with custom limit", func(t *testing.T) {
 		customMax := 25000
-		os.Setenv(EnvMaxAttempts, fmt.Sprintf("%d", customMax))
-		defer os.Unsetenv(EnvMaxAttempts)
+		if err := os.Setenv(EnvMaxAttempts, fmt.Sprintf("%d", customMax)); err != nil {
+			t.Fatalf("Failed to set environment variable: %v", err)
+		}
+		defer func() { _ = os.Unsetenv(EnvMaxAttempts) }()
 
 		s := &StepRetry{MaxAttempts: 15000}
 		err := s.Validate()
@@ -619,8 +633,10 @@ func TestStepRetryValidation(t *testing.T) {
 
 	t.Run("max attempts exceeds custom limit", func(t *testing.T) {
 		customMax := 25000
-		os.Setenv(EnvMaxAttempts, fmt.Sprintf("%d", customMax))
-		defer os.Unsetenv(EnvMaxAttempts)
+		if err := os.Setenv(EnvMaxAttempts, fmt.Sprintf("%d", customMax)); err != nil {
+			t.Fatalf("Failed to set environment variable: %v", err)
+		}
+		defer func() { _ = os.Unsetenv(EnvMaxAttempts) }()
 
 		s := &StepRetry{MaxAttempts: customMax + 1}
 		err := s.Validate()

--- a/repeat_test.go
+++ b/repeat_test.go
@@ -2,6 +2,7 @@ package probe
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 )
@@ -448,3 +449,184 @@ func TestRepeatFunctionality_EdgeCases(t *testing.T) {
 		}
 	})
 }
+
+func TestEnvironmentVariableOverride(t *testing.T) {
+	t.Run("default max repeat count", func(t *testing.T) {
+		// Ensure environment variable is not set
+		os.Unsetenv(EnvMaxRepeatCount)
+
+		max := getMaxRepeatCount()
+		if max != DefaultMaxRepeatCount {
+			t.Errorf("Expected default max repeat count %d, got %d", DefaultMaxRepeatCount, max)
+		}
+	})
+
+	t.Run("custom max repeat count via env", func(t *testing.T) {
+		// Set custom max via environment variable
+		customMax := 50000
+		os.Setenv(EnvMaxRepeatCount, fmt.Sprintf("%d", customMax))
+		defer os.Unsetenv(EnvMaxRepeatCount)
+
+		max := getMaxRepeatCount()
+		if max != customMax {
+			t.Errorf("Expected custom max repeat count %d, got %d", customMax, max)
+		}
+	})
+
+	t.Run("default max attempts", func(t *testing.T) {
+		// Ensure environment variable is not set
+		os.Unsetenv(EnvMaxAttempts)
+
+		max := getMaxAttempts()
+		if max != DefaultMaxAttempts {
+			t.Errorf("Expected default max attempts %d, got %d", DefaultMaxAttempts, max)
+		}
+	})
+
+	t.Run("custom max attempts via env", func(t *testing.T) {
+		// Set custom max via environment variable
+		customMax := 25000
+		os.Setenv(EnvMaxAttempts, fmt.Sprintf("%d", customMax))
+		defer os.Unsetenv(EnvMaxAttempts)
+
+		max := getMaxAttempts()
+		if max != customMax {
+			t.Errorf("Expected custom max attempts %d, got %d", customMax, max)
+		}
+	})
+
+	t.Run("invalid env value falls back to default", func(t *testing.T) {
+		// Set invalid value
+		os.Setenv(EnvMaxRepeatCount, "invalid")
+		defer os.Unsetenv(EnvMaxRepeatCount)
+
+		max := getMaxRepeatCount()
+		if max != DefaultMaxRepeatCount {
+			t.Errorf("Expected default max repeat count %d for invalid env value, got %d", DefaultMaxRepeatCount, max)
+		}
+	})
+
+	t.Run("negative env value falls back to default", func(t *testing.T) {
+		// Set negative value
+		os.Setenv(EnvMaxRepeatCount, "-100")
+		defer os.Unsetenv(EnvMaxRepeatCount)
+
+		max := getMaxRepeatCount()
+		if max != DefaultMaxRepeatCount {
+			t.Errorf("Expected default max repeat count %d for negative env value, got %d", DefaultMaxRepeatCount, max)
+		}
+	})
+}
+
+func TestRepeatValidation(t *testing.T) {
+	t.Run("valid repeat count", func(t *testing.T) {
+		os.Unsetenv(EnvMaxRepeatCount)
+
+		r := &Repeat{Count: 100}
+		err := r.Validate()
+		if err != nil {
+			t.Errorf("Expected no error for valid repeat count, got: %v", err)
+		}
+	})
+
+	t.Run("repeat count at default limit", func(t *testing.T) {
+		os.Unsetenv(EnvMaxRepeatCount)
+
+		r := &Repeat{Count: DefaultMaxRepeatCount}
+		err := r.Validate()
+		if err == nil {
+			t.Errorf("Expected error for repeat count at limit")
+		}
+	})
+
+	t.Run("repeat count exceeds default limit", func(t *testing.T) {
+		os.Unsetenv(EnvMaxRepeatCount)
+
+		r := &Repeat{Count: DefaultMaxRepeatCount + 1}
+		err := r.Validate()
+		if err == nil {
+			t.Errorf("Expected error for repeat count exceeding limit")
+		}
+	})
+
+	t.Run("repeat count valid with custom limit", func(t *testing.T) {
+		customMax := 50000
+		os.Setenv(EnvMaxRepeatCount, fmt.Sprintf("%d", customMax))
+		defer os.Unsetenv(EnvMaxRepeatCount)
+
+		r := &Repeat{Count: 20000}
+		err := r.Validate()
+		if err != nil {
+			t.Errorf("Expected no error for repeat count under custom limit, got: %v", err)
+		}
+	})
+
+	t.Run("repeat count exceeds custom limit", func(t *testing.T) {
+		customMax := 50000
+		os.Setenv(EnvMaxRepeatCount, fmt.Sprintf("%d", customMax))
+		defer os.Unsetenv(EnvMaxRepeatCount)
+
+		r := &Repeat{Count: customMax}
+		err := r.Validate()
+		if err == nil {
+			t.Errorf("Expected error for repeat count at custom limit")
+		}
+	})
+}
+
+func TestStepRetryValidation(t *testing.T) {
+	t.Run("valid max attempts", func(t *testing.T) {
+		os.Unsetenv(EnvMaxAttempts)
+
+		s := &StepRetry{MaxAttempts: 100}
+		err := s.Validate()
+		if err != nil {
+			t.Errorf("Expected no error for valid max attempts, got: %v", err)
+		}
+	})
+
+	t.Run("max attempts at default limit", func(t *testing.T) {
+		os.Unsetenv(EnvMaxAttempts)
+
+		s := &StepRetry{MaxAttempts: DefaultMaxAttempts}
+		err := s.Validate()
+		if err != nil {
+			t.Errorf("Expected no error for max attempts at limit, got: %v", err)
+		}
+	})
+
+	t.Run("max attempts exceeds default limit", func(t *testing.T) {
+		os.Unsetenv(EnvMaxAttempts)
+
+		s := &StepRetry{MaxAttempts: DefaultMaxAttempts + 1}
+		err := s.Validate()
+		if err == nil {
+			t.Errorf("Expected error for max attempts exceeding limit")
+		}
+	})
+
+	t.Run("max attempts valid with custom limit", func(t *testing.T) {
+		customMax := 25000
+		os.Setenv(EnvMaxAttempts, fmt.Sprintf("%d", customMax))
+		defer os.Unsetenv(EnvMaxAttempts)
+
+		s := &StepRetry{MaxAttempts: 15000}
+		err := s.Validate()
+		if err != nil {
+			t.Errorf("Expected no error for max attempts under custom limit, got: %v", err)
+		}
+	})
+
+	t.Run("max attempts exceeds custom limit", func(t *testing.T) {
+		customMax := 25000
+		os.Setenv(EnvMaxAttempts, fmt.Sprintf("%d", customMax))
+		defer os.Unsetenv(EnvMaxAttempts)
+
+		s := &StepRetry{MaxAttempts: customMax + 1}
+		err := s.Validate()
+		if err == nil {
+			t.Errorf("Expected error for max attempts exceeding custom limit")
+		}
+	})
+}
+


### PR DESCRIPTION
## Summary

Add environment variable support to customize the upper limits for `repeat` count and `max_attempts`, allowing users to exceed the default limits when needed while maintaining security through conservative defaults.

## Changes

- Add `PROBE_MAX_REPEAT_COUNT` environment variable to configure repeat count limit
- Add `PROBE_MAX_ATTEMPTS` environment variable to configure max_attempts limit
- Default limits remain at 10000 (backward compatible)
- Add custom validation logic for repeat and retry configurations
- Add comprehensive tests for environment variable handling and validation

## Usage

```bash
# Default (limit: 10000)
probe run workflow.yml

# Custom limit via environment variable
PROBE_MAX_REPEAT_COUNT=100000 probe run workflow.yml

# Persistent configuration
export PROBE_MAX_REPEAT_COUNT=50000
export PROBE_MAX_ATTEMPTS=50000
probe run workflow.yml
```

## Security

- Maintains safe default limit (10000) to prevent accidental resource exhaustion
- Requires explicit environment variable configuration to exceed defaults
- Invalid values (negative numbers, strings) fall back to default values
- Clear error messages indicate current limits and how to override them

## Test plan

- [x] Environment variable reading and application tests
- [x] Validation logic tests
- [x] Fallback to default values for invalid inputs
- [x] All existing tests pass
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)