### PR TITLE
Fix concurrent map writes in async repeat execution

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,5 +1,7 @@
 package probe
 
+import "sync"
+
 // ResponseTime provides response time information for expressions
 type ResponseTime struct {
 	Duration string  `expr:"duration"`
@@ -55,6 +57,7 @@ type JobContext struct {
 	RepeatCurrent int
 	RepeatTotal   int
 	StepCounters  map[int]StepRepeatCounter // step index -> counter
+	countersMu    sync.Mutex                // protects StepCounters for concurrent access
 	// Print writer
 	Printer *Printer
 	// Result for managing job-level output

--- a/executor.go
+++ b/executor.go
@@ -183,7 +183,11 @@ func (e *Executor) appendRepeatStepResults(ctx *JobContext) {
 
 	// Create StepResults for repeat steps and add them to Result
 	for i, step := range e.job.Steps {
-		if counter, exists := ctx.StepCounters[i]; exists {
+		ctx.countersMu.Lock()
+		counter, exists := ctx.StepCounters[i]
+		ctx.countersMu.Unlock()
+
+		if exists {
 			hasTest := step.Test != ""
 
 			// Determine status based on repeat counter results

--- a/step.go
+++ b/step.go
@@ -287,14 +287,15 @@ func (st *Step) getEchoOutput(printer *Printer) string {
 }
 
 func (st *Step) handleRepeatExecution(jCtx *JobContext, name string) {
-
 	// Initialize counter if first execution
+	jCtx.countersMu.Lock()
 	counter, exists := jCtx.StepCounters[st.Idx]
 	if !exists {
 		counter = StepRepeatCounter{
 			Name: name,
 		}
 	}
+	jCtx.countersMu.Unlock()
 
 	// Execute test and update counter
 	hasTest := st.Test != ""
@@ -317,7 +318,9 @@ func (st *Step) handleRepeatExecution(jCtx *JobContext, name string) {
 	counter.LastResult = testResult
 
 	// Store updated counter
+	jCtx.countersMu.Lock()
 	jCtx.StepCounters[st.Idx] = counter
+	jCtx.countersMu.Unlock()
 
 	// Display on first execution and final execution only
 	isFinalExecution := jCtx.RepeatCurrent == jCtx.RepeatTotal
@@ -614,19 +617,23 @@ func (st *Step) handleSkip(name string, jCtx *JobContext) {
 // handleSkipRepeatExecution handles skipped step in repeat mode
 func (st *Step) handleSkipRepeatExecution(jCtx *JobContext, name string) {
 	// Initialize counter if first execution
+	jCtx.countersMu.Lock()
 	counter, exists := jCtx.StepCounters[st.Idx]
 	if !exists {
 		counter = StepRepeatCounter{
 			Name: name,
 		}
 	}
+	jCtx.countersMu.Unlock()
 
 	// Count as successful (skipped is not a failure)
 	counter.SuccessCount++
 	counter.LastResult = true
 
 	// Store updated counter
+	jCtx.countersMu.Lock()
 	jCtx.StepCounters[st.Idx] = counter
+	jCtx.countersMu.Unlock()
 
 	// Display on first execution and final execution only
 	isFinalExecution := jCtx.RepeatCurrent == jCtx.RepeatTotal


### PR DESCRIPTION
## Summary

Fix concurrent map writes error that occurs when using async repeat execution. The error was caused by multiple goroutines simultaneously accessing the `StepCounters` map without synchronization.

## Problem

When `async: true` is enabled in repeat configuration, multiple goroutines execute jobs concurrently. These goroutines all access the shared `StepCounters` map in `JobContext`, causing:

```
fatal error: concurrent map writes
```

## Solution

Add mutex protection for the `StepCounters` map:

- Add `countersMu sync.Mutex` to `JobContext` (context.go)
- Protect all reads/writes to `StepCounters` with mutex locks in:
  - `step.go`: `handleRepeatExecution`
  - `step.go`: `handleSkipRepeatExecution`
  - `executor.go`: `appendRepeatStepResults`

## Changes

- context.go: Add sync.Mutex import and countersMu field
- step.go: Add mutex locks around StepCounters access
- executor.go: Add mutex locks around StepCounters access

## Test Plan

- [x] All existing tests pass
- [x] Async repeat with 10 concurrent executions works
- [x] Async repeat with 100 concurrent executions works
- [x] No concurrent map write errors

## Related

Fixes issue discovered in #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)