### PR TITLE
Rename --rt to --timing and add start timestamp

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -88,8 +88,8 @@ probe ./workflow.yml
 # 詳細出力
 probe ./workflow.yml --verbose
 
-# レスポンス時間を表示
-probe ./workflow.yml --rt
+# タイミング情報を表示（開始時刻、レスポンス時間）
+probe ./workflow.yml --timing
 
 # ジョブ依存関係グラフをASCIIアートで表示
 probe dag ./workflow.yml
@@ -101,7 +101,7 @@ probe dag --mermaid ./workflow.yml
 ### CLIオプション
 - `<workflow>`: YAMLワークフローファイルパスを指定
 - `--verbose`: 詳細出力を有効化
-- `--rt`: レスポンス時間を表示
+- `--timing`: タイミング情報を表示（開始時刻、レスポンス時間）
 - `--help`: ヘルプ情報を表示
 
 ### サブコマンド

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ probe ./workflow.yml
 # Verbose output
 probe ./workflow.yml --verbose
 
-# Show response times
-probe ./workflow.yml --rt
+# Show timing (start time, response time)
+probe ./workflow.yml --timing
 
 # Show job dependency graph as ASCII art
 probe dag ./workflow.yml
@@ -101,7 +101,7 @@ probe dag --mermaid ./workflow.yml
 ### CLI Options
 - `<workflow>`: Specify YAML workflow file path
 - `--verbose`: Enable detailed output
-- `--rt`: Show response times
+- `--timing`: Show timing (start time, response time)
 - `--help`: Show help information
 
 ### Subcommands

--- a/cmd/probe/main.go
+++ b/cmd/probe/main.go
@@ -45,7 +45,7 @@ type Cmd struct {
 	Help           bool
 	Version        bool
 	Verbose        bool
-	RT             bool
+	Timing         bool
 	DagMermaid     bool
 	validFlags     []string
 	ver            string
@@ -57,7 +57,7 @@ type Cmd struct {
 
 func newCmd() *Cmd {
 	return &Cmd{
-		validFlags: []string{"help", "h", "version", "rt", "verbose", "v", "mermaid"},
+		validFlags: []string{"help", "h", "version", "timing", "verbose", "v", "mermaid"},
 		ver:        version,
 		rev:        commit,
 		outWriter:  os.Stdout,
@@ -100,8 +100,8 @@ func (c *Cmd) parseArgs(args []string) error {
 				c.Help = true
 			case "version":
 				c.Version = true
-			case "rt":
-				c.RT = true
+			case "timing":
+				c.Timing = true
 			case "verbose", "v":
 				c.Verbose = true
 			case "mermaid":
@@ -188,7 +188,7 @@ func (c *Cmd) printOptions() {
 	}{
 		{"-h", "--help", "Show command usage"},
 		{"", "--version", "Show version information"},
-		{"", "--rt", "Show response time"},
+		{"", "--timing", "Show timing (start time, response time)"},
 		{"-v", "--verbose", "Show verbose log"},
 	}
 
@@ -273,8 +273,8 @@ func (c *Cmd) runGen() int {
 
 func (c *Cmd) runProbe() int {
 	p := probe.New(c.WorkflowPath, c.Verbose)
-	if c.RT {
-		p.Config.RT = true
+	if c.Timing {
+		p.Config.Timing = true
 	}
 
 	if err := p.Do(); err != nil {

--- a/cmd/probe/main_test.go
+++ b/cmd/probe/main_test.go
@@ -40,8 +40,8 @@ func TestCmd_isValid(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "valid rt flag",
-			flag:     "--rt",
+			name:     "valid timing flag",
+			flag:     "--timing",
 			expected: true,
 		},
 		{
@@ -101,7 +101,7 @@ func TestCmd_usage(t *testing.T) {
 }
 
 func TestCmd_start(t *testing.T) {
-	help := " __  __  __  __  __\n|  ||  ||  ||  || _|\n|  ||  /| |||  /|  |\n| | |  \\| |||  \\| _|\n|_| |_\\_|__||__||__|\n\nProbe - A YAML-based workflow automation tool.\nhttps://github.com/linyows/probe (ver: dev, rev: unknown)\n\nUsage: probe [options] <workflow-file>\n       probe gen <openapi-file>\n       probe dag [--mermaid] <workflow-file>\n\nArguments:\n  workflow-file    Path to YAML workflow file(s). Multiple files can be\n                   specified with comma-separated paths (e.g., \"base.yml,override.yml\")\n                   to merge configurations.\n\nSubcommands:\n  gen <file>       Generate probe workflow YAML from OpenAPI specification\n  dag <file>       Show job dependency graph as ASCII art (default)\n                   Use --mermaid to output in Mermaid format\n\nOptions:\n  -h, --help       Show command usage\n      --version    Show version information\n      --rt         Show response time\n  -v, --verbose    Show verbose log\n"
+	help := " __  __  __  __  __\n|  ||  ||  ||  || _|\n|  ||  /| |||  /|  |\n| | |  \\| |||  \\| _|\n|_| |_\\_|__||__||__|\n\nProbe - A YAML-based workflow automation tool.\nhttps://github.com/linyows/probe (ver: dev, rev: unknown)\n\nUsage: probe [options] <workflow-file>\n       probe gen <openapi-file>\n       probe dag [--mermaid] <workflow-file>\n\nArguments:\n  workflow-file    Path to YAML workflow file(s). Multiple files can be\n                   specified with comma-separated paths (e.g., \"base.yml,override.yml\")\n                   to merge configurations.\n\nSubcommands:\n  gen <file>       Generate probe workflow YAML from OpenAPI specification\n  dag <file>       Show job dependency graph as ASCII art (default)\n                   Use --mermaid to output in Mermaid format\n\nOptions:\n  -h, --help       Show command usage\n      --version    Show version information\n      --timing     Show timing (start time, response time)\n  -v, --verbose    Show verbose log\n"
 
 	tests := []struct {
 		name           string
@@ -109,7 +109,7 @@ func TestCmd_start(t *testing.T) {
 		expectCode     int
 		expectWorkflow string
 		expectVerbose  bool
-		expectRT       bool
+		expectTiming       bool
 		expectHelp     bool
 		expectOutput   string
 	}{
@@ -120,7 +120,7 @@ func TestCmd_start(t *testing.T) {
 			expectHelp:     true,
 			expectWorkflow: "",
 			expectVerbose:  false,
-			expectRT:       false,
+			expectTiming:       false,
 			expectOutput:   help,
 		},
 		{
@@ -130,7 +130,7 @@ func TestCmd_start(t *testing.T) {
 			expectHelp:     false,
 			expectWorkflow: "",
 			expectVerbose:  false,
-			expectRT:       false,
+			expectTiming:       false,
 			expectOutput:   "",
 		},
 		{
@@ -140,7 +140,7 @@ func TestCmd_start(t *testing.T) {
 			expectHelp:     false,
 			expectWorkflow: "",
 			expectVerbose:  false,
-			expectRT:       false,
+			expectTiming:       false,
 			expectOutput:   "[ERROR] workflow is required\n",
 		},
 		{
@@ -150,7 +150,7 @@ func TestCmd_start(t *testing.T) {
 			expectHelp:     false,
 			expectWorkflow: "test.yml",
 			expectVerbose:  false,
-			expectRT:       false,
+			expectTiming:       false,
 			expectOutput:   "",
 		},
 		{
@@ -160,27 +160,27 @@ func TestCmd_start(t *testing.T) {
 			expectHelp:     false,
 			expectWorkflow: "",
 			expectVerbose:  true,
-			expectRT:       false,
+			expectTiming:       false,
 			expectOutput:   "[ERROR] workflow is required\n",
 		},
 		{
-			name:           "rt flag without workflow",
-			args:           []string{"probe", "--rt"},
+			name:           "timing flag without workflow",
+			args:           []string{"probe", "--timing"},
 			expectCode:     1,
 			expectHelp:     false,
 			expectWorkflow: "",
 			expectVerbose:  false,
-			expectRT:       true,
+			expectTiming:       true,
 			expectOutput:   "[ERROR] workflow is required\n",
 		},
 		{
 			name:           "multiple flags with workflow argument",
-			args:           []string{"probe", "--verbose", "--rt", "test.yml"},
+			args:           []string{"probe", "--verbose", "--timing", "test.yml"},
 			expectCode:     0,
 			expectHelp:     false,
 			expectWorkflow: "test.yml",
 			expectVerbose:  true,
-			expectRT:       true,
+			expectTiming:       true,
 			expectOutput:   "",
 		},
 		{
@@ -190,7 +190,7 @@ func TestCmd_start(t *testing.T) {
 			expectHelp:     false,
 			expectWorkflow: "test.yml",
 			expectVerbose:  true,
-			expectRT:       false,
+			expectTiming:       false,
 			expectOutput:   "",
 		},
 		{
@@ -200,7 +200,7 @@ func TestCmd_start(t *testing.T) {
 			expectHelp:     true,
 			expectWorkflow: "",
 			expectVerbose:  false,
-			expectRT:       false,
+			expectTiming:       false,
 			expectOutput:   help,
 		},
 		{
@@ -210,27 +210,27 @@ func TestCmd_start(t *testing.T) {
 			expectHelp:     false,
 			expectWorkflow: "test.yml",
 			expectVerbose:  true,
-			expectRT:       false,
+			expectTiming:       false,
 			expectOutput:   "",
 		},
 		{
 			name:           "options after argument with multiple flags",
-			args:           []string{"probe", "test.yml", "--verbose", "--rt"},
+			args:           []string{"probe", "test.yml", "--verbose", "--timing"},
 			expectCode:     0,
 			expectHelp:     false,
 			expectWorkflow: "test.yml",
 			expectVerbose:  true,
-			expectRT:       true,
+			expectTiming:       true,
 			expectOutput:   "",
 		},
 		{
 			name:           "mixed options before and after argument",
-			args:           []string{"probe", "--verbose", "test.yml", "--rt"},
+			args:           []string{"probe", "--verbose", "test.yml", "--timing"},
 			expectCode:     0,
 			expectHelp:     false,
 			expectWorkflow: "test.yml",
 			expectVerbose:  true,
-			expectRT:       true,
+			expectTiming:       true,
 			expectOutput:   "",
 		},
 		{
@@ -240,7 +240,7 @@ func TestCmd_start(t *testing.T) {
 			expectHelp:     false,
 			expectWorkflow: "test.yml",
 			expectVerbose:  true,
-			expectRT:       false,
+			expectTiming:       false,
 			expectOutput:   "",
 		},
 	}
@@ -263,8 +263,8 @@ func TestCmd_start(t *testing.T) {
 				t.Errorf("start(%v).Verbose = %v, want %v", tt.args, c.Verbose, tt.expectVerbose)
 			}
 
-			if c.RT != tt.expectRT {
-				t.Errorf("start(%v).RT = %v, want %v", tt.args, c.RT, tt.expectRT)
+			if c.Timing != tt.expectTiming {
+				t.Errorf("start(%v).Timing = %v, want %v", tt.args, c.Timing, tt.expectTiming)
 			}
 
 			if c.Help != tt.expectHelp {
@@ -285,7 +285,7 @@ func TestCmd_start(t *testing.T) {
 			}
 
 			// Check validFlags
-			expectedFlags := []string{"help", "h", "version", "rt", "verbose", "v", "mermaid"}
+			expectedFlags := []string{"help", "h", "version", "timing", "verbose", "v", "mermaid"}
 			if len(c.validFlags) != len(expectedFlags) {
 				t.Errorf("start(%v) validFlags length = %d, want %d", tt.args, len(c.validFlags), len(expectedFlags))
 			}

--- a/docs/src/en/guide/introduction/cli-basics.md
+++ b/docs/src/en/guide/introduction/cli-basics.md
@@ -74,12 +74,12 @@ Verbose mode shows:
 [DEBUG] RT: 245ms
 ```
 
-### Response Time Display
+### Timing Display
 
-Show response times for HTTP requests:
+Show timing information (start time and response time):
 
 ```bash
-probe --rt workflow.yml
+probe --timing workflow.yml
 ```
 
 This adds timing information to the output without the full verbosity of `--verbose`.
@@ -89,7 +89,7 @@ This adds timing information to the output without the full verbosity of `--verb
 You can combine multiple options:
 
 ```bash
-probe -v --rt workflow.yml
+probe -v --timing workflow.yml
 ```
 
 ## Multiple File Merging
@@ -248,7 +248,7 @@ probe -v api-tests.yml,local-config.yml
 
 ```bash
 # Run performance tests with timing
-probe --rt --verbose load-test.yml
+probe --timing --verbose load-test.yml
 ```
 
 ## Output Interpretation

--- a/docs/src/ja/guide/introduction/cli-basics.md
+++ b/docs/src/ja/guide/introduction/cli-basics.md
@@ -68,12 +68,12 @@ $ probe workflow.yml --verbose
 [DEBUG] RT: 245ms
 ```
 
-### レスポンス時間表示
+### タイミング情報表示
 
-HTTPリクエストのレスポンス時間を表示：
+開始時刻とレスポンス時間を表示：
 
 ```bash
-$ probe workflow.yml --rt
+$ probe workflow.yml --timing
 ```
 
 これにより、`--verbose`の完全な詳細さなしにタイミング情報が出力に追加されます。
@@ -83,7 +83,7 @@ $ probe workflow.yml --rt
 複数のオプションを組み合わせることができます：
 
 ```bash
-$ probe -v --rt workflow.yml
+$ probe -v --timing workflow.yml
 ```
 
 ## 複数ファイルマージ

--- a/printer.go
+++ b/printer.go
@@ -416,7 +416,7 @@ func (p *Printer) generateJobResultsFromStepResults(stepResults []StepResult) st
 				waitPrefix = colorDim().Sprintf("%s%s → ", IconWait, stepResult.WaitTime)
 			}
 
-			// Add suffix: retry info then response time
+			// Add suffix: retry info then timing (start time + response time)
 			ps := ""
 			if stepResult.RetryAttempt > 0 {
 				retryColor := colorDim()
@@ -425,8 +425,19 @@ func (p *Printer) generateJobResultsFromStepResults(stepResults []StepResult) st
 				}
 				ps += retryColor.Sprintf(" %s %d/%d", IconRetry, stepResult.RetryAttempt, stepResult.RetryMax)
 			}
-			if stepResult.RT != "" {
-				ps += colorDim().Sprintf(" (%s)", stepResult.RT)
+			if !stepResult.StartedAt.IsZero() || stepResult.RT != "" {
+				timing := ""
+				if !stepResult.StartedAt.IsZero() {
+					timing = fmt.Sprintf("@%d", stepResult.StartedAt.Unix())
+				}
+				if stepResult.RT != "" {
+					if timing != "" {
+						timing += " " + stepResult.RT
+					} else {
+						timing = stepResult.RT
+					}
+				}
+				ps += colorDim().Sprintf(" (%s)", timing)
 			}
 
 			switch stepResult.Status {

--- a/probe.go
+++ b/probe.go
@@ -22,7 +22,7 @@ type Probe struct {
 type Config struct {
 	Log     io.Writer
 	Verbose bool
-	RT      bool
+	Timing  bool
 }
 
 func New(path string, v bool) *Probe {
@@ -36,7 +36,7 @@ func New(path string, v bool) *Probe {
 		Config: Config{
 			Log:     os.Stdout,
 			Verbose: v,
-			RT:      false,
+			Timing:  false,
 		},
 	}
 }

--- a/probe_test.go
+++ b/probe_test.go
@@ -16,7 +16,7 @@ func TestLoad(t *testing.T) {
 		Config: Config{
 			Log:     os.Stdout,
 			Verbose: true,
-			RT:      false,
+			Timing:  false,
 		},
 	}
 	err := p.Load()
@@ -49,7 +49,7 @@ func TestNew(t *testing.T) {
 				Config: Config{
 					Log:     os.Stdout,
 					Verbose: true,
-					RT:      false,
+					Timing:  false,
 				},
 			},
 		},
@@ -62,7 +62,7 @@ func TestNew(t *testing.T) {
 				Config: Config{
 					Log:     os.Stdout,
 					Verbose: false,
-					RT:      false,
+					Timing:  false,
 				},
 			},
 		},
@@ -77,8 +77,8 @@ func TestNew(t *testing.T) {
 			if got.Config.Verbose != tt.expected.Config.Verbose {
 				t.Errorf("Config.Verbose = %v, want %v", got.Config.Verbose, tt.expected.Config.Verbose)
 			}
-			if got.Config.RT != tt.expected.Config.RT {
-				t.Errorf("Config.RT = %v, want %v", got.Config.RT, tt.expected.Config.RT)
+			if got.Config.Timing != tt.expected.Config.Timing {
+				t.Errorf("Config.Timing = %v, want %v", got.Config.Timing, tt.expected.Config.Timing)
 			}
 		})
 	}
@@ -268,7 +268,7 @@ func TestLoadWithInvalidYaml(t *testing.T) {
 		Config: Config{
 			Log:     io.Discard,
 			Verbose: false,
-			RT:      false,
+			Timing:  false,
 		},
 	}
 
@@ -316,7 +316,7 @@ func TestDoWithInvalidPath(t *testing.T) {
 		Config: Config{
 			Log:     io.Discard,
 			Verbose: false,
-			RT:      false,
+			Timing:  false,
 		},
 	}
 

--- a/result.go
+++ b/result.go
@@ -29,6 +29,7 @@ type StepResult struct {
 	Index         int
 	Name          string
 	Status        StatusType
+	StartedAt     time.Time
 	RT            string
 	RTSec         float64
 	WaitTime      string

--- a/step.go
+++ b/step.go
@@ -32,6 +32,7 @@ type Step struct {
 	err          error
 	ctx          StepContext
 	retryAttempt int
+	startedAt    time.Time
 	Idx          int          `yaml:"-"`
 	Expr         *Expr        `yaml:"-"`
 	actionRunner ActionRunner `yaml:"-"`
@@ -45,6 +46,7 @@ func (st *Step) Do(jCtx *JobContext) {
 	}
 
 	// 2. Action execution phase
+	st.startedAt = time.Now()
 	actionResult, err := st.executeAction(name, jCtx)
 	if err != nil {
 		st.handleActionError(err, name, jCtx)
@@ -310,9 +312,14 @@ func (st *Step) createStepResult(name string, jCtx *JobContext, repeatCounter *S
 		result.RetryMax = st.Retry.MaxAttempts
 	}
 
-	if jCtx.RT && st.ctx.RT.Duration != "" {
-		result.RT = st.ctx.RT.Duration
-		result.RTSec = st.ctx.RT.Sec
+	if jCtx.Timing {
+		if !st.startedAt.IsZero() {
+			result.StartedAt = st.startedAt
+		}
+		if st.ctx.RT.Duration != "" {
+			result.RT = st.ctx.RT.Duration
+			result.RTSec = st.ctx.RT.Sec
+		}
 	}
 	if v, ok := st.ctx.Res["report"]; ok {
 		if report, sok := v.(string); sok {
@@ -751,9 +758,14 @@ func (st *Step) createFailedStepResult(name string, jCtx *JobContext, repeatCoun
 		result.RetryMax = st.Retry.MaxAttempts
 	}
 
-	if jCtx.RT && st.ctx.RT.Duration != "" {
-		result.RT = st.ctx.RT.Duration
-		result.RTSec = st.ctx.RT.Sec
+	if jCtx.Timing {
+		if !st.startedAt.IsZero() {
+			result.StartedAt = st.startedAt
+		}
+		if st.ctx.RT.Duration != "" {
+			result.RT = st.ctx.RT.Duration
+			result.RTSec = st.ctx.RT.Sec
+		}
 	}
 	if v, ok := st.ctx.Res["report"]; ok {
 		if report, sok := v.(string); sok {

--- a/step_test.go
+++ b/step_test.go
@@ -443,7 +443,7 @@ func TestStep_createStepResult_WithRepeatCounter(t *testing.T) {
 		},
 	}
 	jCtx := &JobContext{
-		Config:  Config{RT: true},
+		Config:  Config{Timing: true},
 		Printer: newBufferPrinter(),
 	}
 	name := "Test Step"
@@ -489,7 +489,7 @@ func TestStep_createFailedStepResult(t *testing.T) {
 		},
 	}
 	jCtx := &JobContext{
-		Config: Config{RT: true},
+		Config: Config{Timing: true},
 	}
 	name := "Failed Step"
 
@@ -542,7 +542,7 @@ func TestStep_createFailedStepResult_WithRepeatCounter(t *testing.T) {
 		},
 	}
 	jCtx := &JobContext{
-		Config: Config{RT: true},
+		Config: Config{Timing: true},
 	}
 	name := "Timeout Step"
 	counter := &StepRepeatCounter{


### PR DESCRIPTION
## Summary
- Rename `--rt` flag to `--timing` to better reflect its broader scope
- Add step execution start time (unix timestamp) to the timing output
- Display format: `(@1744182725 120ms)` combining start time and response time

## Test plan
- [x] All existing tests updated and passing
- [x] Run `probe --timing workflow.yml` and verify output shows `(@<unix_ts> <duration>)` format
- [x] Run `probe --help` and verify `--timing` option is listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)