### PR TITLE
Record nanosecond send timing via X-Send-Timestamp-Ns header

### DIFF
--- a/mail/id.go
+++ b/mail/id.go
@@ -2,21 +2,8 @@ package mail
 
 import (
 	"crypto/rand"
-	"crypto/sha1"
 	"encoding/hex"
-	"fmt"
-	"io"
-	"time"
 )
-
-func HashID() string {
-	hash := sha1.New()
-	timestamp := time.Now().UnixNano()
-	if _, err := io.WriteString(hash, fmt.Sprintf("%d", timestamp)); err != nil {
-		return ""
-	}
-	return fmt.Sprintf("%x", hash.Sum(nil))
-}
 
 func OptimisticUID() (string, error) {
 	b := make([]byte, 16)

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/smtp"
 	"os"
+	"time"
 )
 
 type Mail struct {
@@ -70,7 +71,7 @@ func (m *Mail) Send() error {
 			return fmt.Errorf("smtp data error: %w", err)
 		}
 
-		_, err = w.Write(m.appendIDtoSubject(m.Data))
+		_, err = w.Write(m.appendSendTimestamp(m.appendIDtoSubject(m.Data)))
 		if err != nil {
 			return fmt.Errorf("smtp data write error: %w", err)
 		}
@@ -89,27 +90,47 @@ func getFQDN() string {
 	}
 	hostname, err := os.Hostname()
 	if err != nil {
-		return "localhost"
+		// RFC 6761 reserves .invalid for cases where a real domain is unavailable.
+		return "localhost.invalid"
 	}
 	return hostname
 }
 
-func genMsgID(id string) string {
-	return fmt.Sprintf("<%s@%s>", id, getFQDN())
+// genMessageID returns the id-left component (ns + 128bit random) and the
+// fully bracketed Message-ID. The id-left is reused as the Subject tracking
+// suffix so each mail's Message-ID and Subject can be cross-referenced.
+func genMessageID() (idLeft, full string) {
+	ns := time.Now().UnixNano()
+	uid, err := OptimisticUID()
+	if err != nil {
+		idLeft = fmt.Sprintf("%d", ns)
+	} else {
+		idLeft = fmt.Sprintf("%d.%s", ns, uid)
+	}
+	full = fmt.Sprintf("<%s@%s>", idLeft, getFQDN())
+	return
+}
+
+// appendSendTimestamp prepends an X-Send-Timestamp-Ns header carrying the
+// current time in Unix nanoseconds, captured at the moment the message is
+// about to be written to the SMTP DATA stream.
+func (m *Mail) appendSendTimestamp(data []byte) []byte {
+	h := []byte(fmt.Sprintf("X-Send-Timestamp-Ns: %d\n", time.Now().UnixNano()))
+	return append(h, data...)
 }
 
 func (m *Mail) appendIDtoSubject(data []byte) []byte {
-	id := HashID()
+	idLeft, msgID := genMessageID()
 	lines := bytes.Split(data, []byte("\n"))
 
 	for i, line := range lines {
 		if bytes.HasPrefix(line, []byte("Subject:")) {
-			lines[i] = append(line, []byte(" - "+id)...)
+			lines[i] = append(line, []byte(" - "+idLeft)...)
 			break
 		}
 	}
 
-	mid := []byte("Message-ID: " + genMsgID(id))
+	mid := []byte("Message-ID: " + msgID)
 	lines = append([][]byte{mid}, lines...)
 
 	return bytes.Join(lines, []byte("\n"))

--- a/mail/mail_test.go
+++ b/mail/mail_test.go
@@ -97,7 +97,7 @@ func TestGenMessageID(t *testing.T) {
 		t.Errorf("idLeft random part length = %d, want 32", len(uidPart))
 	}
 	for _, c := range uidPart {
-		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("idLeft random part is not lowercase hex: %q", uidPart)
 			break
 		}

--- a/mail/mail_test.go
+++ b/mail/mail_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/smtp"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -79,44 +80,50 @@ func TestGetFQDN(t *testing.T) {
 	}
 }
 
-func TestGenMsgID(t *testing.T) {
-	tests := []struct {
-		name       string
-		id         string
-		wantPrefix string
-		wantSuffix string
-	}{
-		{
-			name:       "normal id",
-			id:         "test123",
-			wantPrefix: "<test123@",
-			wantSuffix: ">",
-		},
-		{
-			name:       "empty id",
-			id:         "",
-			wantPrefix: "<@",
-			wantSuffix: ">",
-		},
-		{
-			name:       "special characters",
-			id:         "abc-123_def",
-			wantPrefix: "<abc-123_def@",
-			wantSuffix: ">",
-		},
+func TestGenMessageID(t *testing.T) {
+	idLeft, full := genMessageID()
+
+	// idLeft must be "<ns>.<32-hex>"
+	dot := strings.IndexByte(idLeft, '.')
+	if dot <= 0 {
+		t.Fatalf("idLeft missing '.' separator: %q", idLeft)
+	}
+	nsPart := idLeft[:dot]
+	uidPart := idLeft[dot+1:]
+	if _, err := strconv.ParseInt(nsPart, 10, 64); err != nil {
+		t.Errorf("idLeft prefix is not numeric ns: %q", nsPart)
+	}
+	if len(uidPart) != 32 {
+		t.Errorf("idLeft random part length = %d, want 32", len(uidPart))
+	}
+	for _, c := range uidPart {
+		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
+			t.Errorf("idLeft random part is not lowercase hex: %q", uidPart)
+			break
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			msgID := genMsgID(tt.id)
+	// full must be "<idLeft@host>"
+	if !strings.HasPrefix(full, "<"+idLeft+"@") {
+		t.Errorf("full Message-ID prefix mismatch: got %q, want prefix <%s@", full, idLeft)
+	}
+	if !strings.HasSuffix(full, ">") {
+		t.Errorf("full Message-ID missing trailing '>': %q", full)
+	}
+	host := strings.TrimSuffix(strings.TrimPrefix(full, "<"+idLeft+"@"), ">")
+	if host == "" {
+		t.Errorf("full Message-ID has empty host part: %q", full)
+	}
 
-			if !strings.HasPrefix(msgID, tt.wantPrefix) {
-				t.Errorf("expected Message-ID to start with '%s', got %s", tt.wantPrefix, msgID)
-			}
-			if !strings.HasSuffix(msgID, tt.wantSuffix) {
-				t.Errorf("expected Message-ID to end with '%s', got %s", tt.wantSuffix, msgID)
-			}
-		})
+	// concurrent calls must produce distinct IDs
+	const n = 64
+	seen := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		l, _ := genMessageID()
+		if _, dup := seen[l]; dup {
+			t.Fatalf("genMessageID produced duplicate idLeft: %s", l)
+		}
+		seen[l] = struct{}{}
 	}
 }
 
@@ -193,6 +200,38 @@ func TestMail_AppendIDtoSubject(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMail_AppendSendTimestamp(t *testing.T) {
+	mail := &Mail{}
+	original := []byte("Subject: Test\nFrom: a@b\n\nBody")
+
+	before := time.Now().UnixNano()
+	result := mail.appendSendTimestamp(original)
+	after := time.Now().UnixNano()
+
+	lines := bytes.SplitN(result, []byte("\n"), 2)
+	if len(lines) != 2 {
+		t.Fatalf("expected at least one prepended line, got %q", result)
+	}
+
+	prefix := []byte("X-Send-Timestamp-Ns: ")
+	if !bytes.HasPrefix(lines[0], prefix) {
+		t.Fatalf("expected first line to start with %q, got %q", prefix, lines[0])
+	}
+
+	tsStr := string(bytes.TrimPrefix(lines[0], prefix))
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		t.Fatalf("expected numeric timestamp, got %q: %v", tsStr, err)
+	}
+	if ts < before || ts > after {
+		t.Errorf("timestamp %d not within [%d, %d]", ts, before, after)
+	}
+
+	if !bytes.Equal(lines[1], original) {
+		t.Errorf("original payload mutated: got %q, want %q", lines[1], original)
 	}
 }
 


### PR DESCRIPTION
## Summary
- RFC 5322 `Date:` headers only carry second precision, which is too coarse for SMTP send-timing analysis. Add an `X-Send-Timestamp-Ns` header that captures the time (in Unix nanoseconds) at the moment the message is written to the SMTP `DATA` stream.
- Switch the `Message-ID` and Subject tracking suffix to `<unix-nano>.<128bit-random>` so each mail can be cross-referenced with sub-second accuracy.
- Change the `getFQDN()` fallback from `localhost` to `localhost.invalid` (RFC 6761 reserved TLD) when the real hostname is unavailable.
- Remove the unused `HashID()` helper.

## Test plan
- [x] `go test ./mail/...`
- [ ] Send through a real SMTP server and verify that `X-Send-Timestamp-Ns`, `Message-ID`, and `Subject` are populated as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)