### PR TITLE
Record echo output per iteration for repeat steps

### DIFF
--- a/examples/repeat-literal.yml
+++ b/examples/repeat-literal.yml
@@ -29,3 +29,9 @@ jobs:
       echo: |
         Calculated value: {{repeat_index * 10}}
       wait: 500ms
+
+    - name: Per-iteration echo recorded in report
+      uses: hello
+      echo: |
+        iteration {{repeat_index}}: token=tk-{{repeat_index * 7}}
+      wait: 200ms

--- a/printer.go
+++ b/printer.go
@@ -406,6 +406,13 @@ func (p *Printer) generateJobResultsFromStepResults(stepResults []StepResult) st
 		if stepResult.RepeatCounter != nil {
 			p.printStepRepeatStart(stepResult.Index, stepResult.RepeatCounter.Name, stepResult.RepeatCounter.SuccessCount+stepResult.RepeatCounter.FailureCount, &output)
 			p.printStepRepeatResult(stepResult.RepeatCounter, stepResult.HasTest, &output)
+			for _, echo := range stepResult.RepeatCounter.EchoOutputs {
+				echo = strings.TrimRight(echo, " \n\t\r")
+				if echo == "" {
+					continue
+				}
+				output.WriteString(colorInfo().Sprint(echo) + "\n")
+			}
 		} else {
 			// Generate regular step output
 			num := colorDim().Sprintf("%2d.", stepResult.Index)

--- a/printer_test.go
+++ b/printer_test.go
@@ -1528,3 +1528,47 @@ func TestPrinter_generateJobResultsFromStepResults_ReportNewlineFormatting(t *te
 		})
 	}
 }
+
+func TestPrinter_generateJobResultsFromStepResults_RepeatEchoOutputs(t *testing.T) {
+	color.NoColor = true
+	defer func() { color.NoColor = false }()
+
+	printer := newBufferPrinter()
+
+	stepResult := StepResult{
+		Index:   1,
+		Name:    "Repeat Step",
+		Status:  StatusSuccess,
+		HasTest: false,
+		RepeatCounter: &StepRepeatCounter{
+			Name:         "Repeat Step",
+			SuccessCount: 3,
+			FailureCount: 0,
+			RepeatTotal:  3,
+			EchoOutputs: []string{
+				"       iteration 1\n",
+				"       iteration 2\n",
+				"       iteration 3\n",
+			},
+		},
+	}
+
+	got := printer.generateJobResultsFromStepResults([]StepResult{stepResult})
+
+	for i := 1; i <= 3; i++ {
+		want := fmt.Sprintf("iteration %d", i)
+		if !strings.Contains(got, want) {
+			t.Errorf("output should contain %q, got:\n%s", want, got)
+		}
+	}
+
+	idx1 := strings.Index(got, "iteration 1")
+	idx2 := strings.Index(got, "iteration 2")
+	idx3 := strings.Index(got, "iteration 3")
+	if idx1 >= idx2 || idx2 >= idx3 {
+		t.Errorf("echo outputs should appear in order, got positions %d, %d, %d", idx1, idx2, idx3)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("output should end with newline, got %q", got)
+	}
+}

--- a/result.go
+++ b/result.go
@@ -21,7 +21,8 @@ type StepRepeatCounter struct {
 	FailureCount int
 	Name         string
 	LastResult   bool
-	RepeatTotal  int // Total number of times the step should be repeated
+	RepeatTotal  int      // Total number of times the step should be repeated
+	EchoOutputs  []string // Formatted echo output captured per iteration
 }
 
 // StepResult represents the result of a step execution

--- a/step.go
+++ b/step.go
@@ -340,7 +340,7 @@ func (st *Step) createStepResult(name string, jCtx *JobContext, repeatCounter *S
 		result.Status = StatusWarning
 	}
 
-	if st.Echo != "" {
+	if st.Echo != "" && repeatCounter == nil {
 		result.EchoOutput = st.getEchoOutput(jCtx.Printer)
 	}
 
@@ -369,6 +369,15 @@ func (st *Step) handleRepeatExecution(jCtx *JobContext, name string, hasError bo
 		}
 	}
 
+	// Evaluate echo before taking the lock so we can store the formatted
+	// output on the counter alongside the success/failure increment.
+	var echoRaw, echoFormatted string
+	var echoErr error
+	if st.Echo != "" {
+		echoRaw, echoErr = st.Expr.EvalTemplate(st.Echo, st.ctx)
+		echoFormatted = jCtx.Printer.generateEchoOutput(echoRaw, echoErr)
+	}
+
 	// Update counter atomically with lock held throughout
 	jCtx.countersMu.Lock()
 	counter, exists := jCtx.StepCounters[st.Idx]
@@ -386,6 +395,10 @@ func (st *Step) handleRepeatExecution(jCtx *JobContext, name string, hasError bo
 		counter.SuccessCount++
 	}
 	counter.LastResult = testResult
+
+	if st.Echo != "" {
+		counter.EchoOutputs = append(counter.EchoOutputs, echoFormatted)
+	}
 
 	// Store updated counter back to map
 	jCtx.StepCounters[st.Idx] = counter
@@ -407,9 +420,12 @@ func (st *Step) handleRepeatExecution(jCtx *JobContext, name string, hasError bo
 		}
 	}
 
-	// Handle echo output
 	if st.Echo != "" {
-		st.DoEcho(jCtx)
+		if echoErr != nil {
+			jCtx.Printer.LogError("Echo evaluation failed: %#v (input: %s)", echoErr, st.Echo)
+		} else {
+			jCtx.Printer.PrintEchoContent(echoRaw)
+		}
 	}
 }
 
@@ -439,15 +455,6 @@ func (st *Step) DoTest(printer *Printer) (string, bool) {
 	}
 
 	return "", true
-}
-
-func (st *Step) DoEcho(jCtx *JobContext) {
-	exprOut, err := st.Expr.EvalTemplate(st.Echo, st.ctx)
-	if err != nil {
-		jCtx.Printer.LogError("Echo evaluation failed: %#v (input: %s)", err, st.Echo)
-	} else {
-		jCtx.Printer.PrintEchoContent(exprOut)
-	}
 }
 
 func (st *Step) SetCtx(j JobContext, override map[string]any) {

--- a/step_test.go
+++ b/step_test.go
@@ -1581,6 +1581,60 @@ func TestStep_DefaultStepTimeout_Value(t *testing.T) {
 	}
 }
 
+func TestStep_handleRepeatExecution_AccumulatesEchoOutputs(t *testing.T) {
+	step := &Step{
+		Idx:  1,
+		Echo: "iteration {{vars.i}}",
+		Expr: &Expr{},
+	}
+
+	jCtx := &JobContext{
+		Printer:      newBufferPrinter(),
+		StepCounters: make(map[int]StepRepeatCounter),
+		countersMu:   &sync.Mutex{},
+		RepeatTotal:  3,
+		Result:       NewResult(),
+		CurrentJobID: "job-1",
+	}
+	jCtx.Result.Jobs["job-1"] = &JobResult{JobID: "job-1"}
+
+	for i := 1; i <= 3; i++ {
+		jCtx.RepeatCurrent = i
+		step.ctx = StepContext{
+			Vars: map[string]any{"i": i},
+		}
+		step.handleRepeatExecution(jCtx, "Repeat Step", false)
+	}
+
+	counter, ok := jCtx.StepCounters[step.Idx]
+	if !ok {
+		t.Fatal("StepCounters[1] missing")
+	}
+	if got := len(counter.EchoOutputs); got != 3 {
+		t.Fatalf("EchoOutputs length = %d, want 3", got)
+	}
+	for i, out := range counter.EchoOutputs {
+		want := fmt.Sprintf("iteration %d", i+1)
+		if !strings.Contains(out, want) {
+			t.Errorf("EchoOutputs[%d] = %q, want to contain %q", i, out, want)
+		}
+	}
+
+	stepResults := jCtx.Result.Jobs["job-1"].StepResults
+	if len(stepResults) != 1 {
+		t.Fatalf("StepResults length = %d, want 1", len(stepResults))
+	}
+	if stepResults[0].EchoOutput != "" {
+		t.Errorf("StepResult.EchoOutput should be empty for repeat steps, got %q", stepResults[0].EchoOutput)
+	}
+	if stepResults[0].RepeatCounter == nil {
+		t.Fatal("StepResult.RepeatCounter is nil")
+	}
+	if got := len(stepResults[0].RepeatCounter.EchoOutputs); got != 3 {
+		t.Errorf("StepResult.RepeatCounter.EchoOutputs length = %d, want 3", got)
+	}
+}
+
 func TestParseExitStatus(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Steps with `repeat: N` previously dropped echo output from the final report: every iteration was printed to verbose stdout but the repeat-summary renderer never read `StepResult.EchoOutput`, so iteration-specific echoes (e.g. `{{vars.i}}`) were invisible in the report.
- Carry an `EchoOutputs []string` slice on `StepRepeatCounter` and append the formatted echo on every iteration under the existing counters lock.
- Render each entry under the repeat summary so per-iteration echoes appear in the report, indented as sub-content of the summary.
- Drop `StepResult.EchoOutput` for repeat steps to avoid two sources of truth, and remove the now-unused `Step.DoEcho` helper.

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] `go test -race` for the repeat/echo paths
- [ ] Manually run a workflow with `repeat: 3` and `echo: "iteration {{vars.i}}"` and confirm all three iterations show up in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)