### PR TITLE
Fix recursive RLock deadlock in JobScheduler

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -140,6 +140,14 @@ func (js *JobScheduler) CanRunJob(jobID string) bool {
 	js.mutex.RLock()
 	defer js.mutex.RUnlock()
 
+	return js.canRunJobLocked(jobID)
+}
+
+// canRunJobLocked is the lock-free implementation of CanRunJob.
+// Callers must already hold js.mutex (read or write). Splitting this out
+// avoids re-entering RLock from GetRunnableJobs, which would deadlock when
+// a writer is waiting on the same mutex.
+func (js *JobScheduler) canRunJobLocked(jobID string) bool {
 	job := js.jobs[jobID]
 	if js.status[jobID] != JobPending {
 		return false
@@ -147,7 +155,7 @@ func (js *JobScheduler) CanRunJob(jobID string) bool {
 
 	// Check if all dependencies are fully completed (all repeats done)
 	for _, dep := range job.Needs {
-		if !js.isJobFullyCompleted(dep) {
+		if !js.isJobFullyCompletedLocked(dep) {
 			return false
 		}
 	}
@@ -155,8 +163,9 @@ func (js *JobScheduler) CanRunJob(jobID string) bool {
 	return true
 }
 
-// isJobFullyCompleted checks if a job has completed all its repeat executions
-func (js *JobScheduler) isJobFullyCompleted(jobID string) bool {
+// isJobFullyCompletedLocked is the lock-free check for whether a job has
+// finished all of its repeat executions. Callers must already hold js.mutex.
+func (js *JobScheduler) isJobFullyCompletedLocked(jobID string) bool {
 	if js.status[jobID] != JobCompleted {
 		return false
 	}
@@ -211,7 +220,7 @@ func (js *JobScheduler) GetRunnableJobs() []string {
 
 	var runnable []string
 	for jobID := range js.jobs {
-		if js.CanRunJob(jobID) {
+		if js.canRunJobLocked(jobID) {
 			runnable = append(runnable, jobID)
 		}
 	}

--- a/scheduler.go
+++ b/scheduler.go
@@ -148,7 +148,13 @@ func (js *JobScheduler) CanRunJob(jobID string) bool {
 // avoids re-entering RLock from GetRunnableJobs, which would deadlock when
 // a writer is waiting on the same mutex.
 func (js *JobScheduler) canRunJobLocked(jobID string) bool {
-	job := js.jobs[jobID]
+	job, ok := js.jobs[jobID]
+	if !ok {
+		// Unknown job: a missing key returns a nil *Job, and ranging
+		// over job.Needs below would panic. CanRunJob is exported, so
+		// guard external callers by reporting "not runnable" instead.
+		return false
+	}
 	if js.status[jobID] != JobPending {
 		return false
 	}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -145,6 +145,29 @@ func TestJobScheduler_MarkJobsWithFailedDependencies(t *testing.T) {
 	})
 }
 
+func TestJobScheduler_CanRunJob_UnknownIDReturnsFalse(t *testing.T) {
+	// CanRunJob is exported, so callers may pass arbitrary IDs. Looking up
+	// a missing ID in js.jobs returns nil; without a guard, ranging over
+	// the nil *Job's Needs slice panics. The function must instead return
+	// false for unknown jobs.
+	scheduler := NewJobScheduler()
+
+	known := &Job{ID: "known", Name: "known"}
+	if err := scheduler.AddJob(known); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("CanRunJob panicked on unknown jobID: %v", r)
+		}
+	}()
+
+	if got := scheduler.CanRunJob("does-not-exist"); got {
+		t.Errorf("CanRunJob(unknown) = true, want false")
+	}
+}
+
 func TestJobScheduler_NoDeadlockOnConcurrentReadAndWrite(t *testing.T) {
 	// Regression test for the recursive RLock deadlock.
 	//

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1,8 +1,11 @@
 package probe
 
 import (
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestJobScheduler_MarkJobsWithFailedDependencies(t *testing.T) {
@@ -140,6 +143,63 @@ func TestJobScheduler_MarkJobsWithFailedDependencies(t *testing.T) {
 			t.Error("Expected job3 to be runnable")
 		}
 	})
+}
+
+func TestJobScheduler_NoDeadlockOnConcurrentReadAndWrite(t *testing.T) {
+	// Regression test for the recursive RLock deadlock.
+	//
+	// GetRunnableJobs holds RLock, then calls CanRunJob which tries to
+	// acquire RLock again. Per Go's sync.RWMutex contract, a blocked Lock
+	// call excludes new readers from acquiring the lock to avoid writer
+	// starvation; therefore, if any writer is waiting, the second RLock
+	// inside the same goroutine deadlocks.
+	//
+	// To reproduce reliably, we spam GetRunnableJobs from many goroutines
+	// while concurrently calling Lock-acquiring methods such as
+	// SetJobStatus and IncrementRepeatCounter. With the bug present, the
+	// scheduler hangs and the timeout below trips.
+	scheduler := NewJobScheduler()
+	const jobCount = 5
+	for i := 0; i < jobCount; i++ {
+		job := &Job{
+			Name:  fmt.Sprintf("job-%d", i),
+			ID:    fmt.Sprintf("id-%d", i),
+			Steps: []*Step{},
+		}
+		if err := scheduler.AddJob(job); err != nil {
+			t.Fatalf("AddJob: %v", err)
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+		const iterations = 500
+		for i := 0; i < iterations; i++ {
+			wg.Add(3)
+			go func() {
+				defer wg.Done()
+				_ = scheduler.GetRunnableJobs()
+			}()
+			go func(idx int) {
+				defer wg.Done()
+				scheduler.SetJobStatus(fmt.Sprintf("id-%d", idx%jobCount), JobRunning, false)
+			}(i)
+			go func(idx int) {
+				defer wg.Done()
+				scheduler.IncrementRepeatCounter(fmt.Sprintf("id-%d", idx%jobCount))
+			}(i)
+		}
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		// reached without deadlock
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: scheduler operations did not finish within 5s (recursive RLock)")
+	}
 }
 
 func TestJobScheduler_ValidateDependencies(t *testing.T) {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -961,12 +961,17 @@ func TestWorkflowBuffer_ConcurrentAccess(t *testing.T) {
 		done <- true
 	}()
 
-	// Goroutine 2: Read job buffer
+	// Goroutine 2: Read job buffer.
+	// AddStepResult writes StepResults under JobResult.mutex, so readers
+	// must take the same lock — see printer.go where reports do exactly
+	// this. Reading without the lock races with the writer goroutine.
 	go func() {
 		for range 5 {
 			jobResult := wb.Jobs[jobID]
 			if jobResult != nil {
+				jobResult.mutex.Lock()
 				_ = len(jobResult.StepResults)
+				jobResult.mutex.Unlock()
 			}
 		}
 		done <- true
@@ -981,7 +986,10 @@ func TestWorkflowBuffer_ConcurrentAccess(t *testing.T) {
 	if !exists {
 		t.Fatal("Job buffer should exist after concurrent operations")
 	}
-	if len(jobResult.StepResults) != 10 {
-		t.Errorf("Expected 10 step results after concurrent operations, got %d", len(jobResult.StepResults))
+	jobResult.mutex.Lock()
+	stepCount := len(jobResult.StepResults)
+	jobResult.mutex.Unlock()
+	if stepCount != 10 {
+		t.Errorf("Expected 10 step results after concurrent operations, got %d", stepCount)
 	}
 }


### PR DESCRIPTION
## Summary
- `GetRunnableJobs` held `RLock` and re-entered the same lock via `CanRunJob`. Per `sync.RWMutex` semantics, new readers are blocked while a writer is waiting, so a concurrent `SetJobStatus` / `IncrementRepeatCounter` could deadlock the scheduler.
- Split `CanRunJob` and `isJobFullyCompleted` into lock-free `*Locked` helpers; `GetRunnableJobs` now calls the locked variant from inside its own `RLock`.
- Tightened `TestWorkflowBuffer_ConcurrentAccess` so the reader goroutine acquires `JobResult.mutex` (matching `printer.go`); the previous version was a real data race exposed by `-race`.

## Test plan
- [x] `go test -race -run 'TestJobScheduler_NoDeadlockOnConcurrentReadAndWrite' ./...` — new regression test fails on the previous code (5s timeout) and passes after the fix.
- [x] `go test -race -run 'TestWorkflowBuffer_ConcurrentAccess' ./...` — passes with the lock-aware reader.
- [x] `go test -race ./...` — full suite, all packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)