### PR TITLE
Remove DEBUG-prefixed Info logs from http client

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/linyows/probe"
 )
 
@@ -95,10 +94,6 @@ func (r *Req) Do() (*Result, error) {
 	if r.URL == "" {
 		return nil, errors.New("Req.URL is required")
 	}
-
-	// Debug: log the body content and content-type
-	log := hclog.Default()
-	log.Info("DEBUG: HTTP Request Body", "body", r.Body, "headers", r.Header)
 
 	req, err := hp.NewRequest(r.Method, r.URL, strings.NewReader(r.Body))
 	if err != nil {
@@ -310,10 +305,8 @@ func Request(data map[string]any, opts ...Option) (map[string]any, error) {
 	// Extract custom headers and merge with defaults before MapToStructByTags
 	var customHeaders map[string]string
 	if headersInterface, exists := m["headers"]; exists {
-		hclog.Default().Info("DEBUG: Processing headers", "headers", headersInterface, "type", fmt.Sprintf("%T", headersInterface))
 		if headers, ok := headersInterface.(map[string]string); ok {
 			customHeaders = headers
-			hclog.Default().Info("DEBUG: Headers matched map[string]string")
 		} else if headersInterfaceMap, ok := headersInterface.(map[string]any); ok {
 			// Convert map[string]interface{} to map[string]string
 			customHeaders = make(map[string]string)
@@ -322,20 +315,7 @@ func Request(data map[string]any, opts ...Option) (map[string]any, error) {
 					customHeaders[k] = strVal
 				}
 			}
-			hclog.Default().Info("DEBUG: Headers matched map[string]interface{}")
-		} else if headersAnyMap, ok := headersInterface.(map[string]any); ok {
-			// Convert map[string]any to map[string]string
-			customHeaders = make(map[string]string)
-			for k, v := range headersAnyMap {
-				if strVal, ok := v.(string); ok {
-					customHeaders[k] = strVal
-				}
-			}
-			hclog.Default().Info("DEBUG: Headers matched map[string]any")
-		} else {
-			hclog.Default().Info("DEBUG: Headers type not matched")
 		}
-		hclog.Default().Info("DEBUG: Extracted custom headers", "customHeaders", customHeaders)
 	}
 
 	// Create new request with merged headers

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	hp "net/http"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/jarcoal/httpmock"
 	"github.com/linyows/probe"
 )
@@ -607,5 +609,50 @@ func TestMergeHeaders(t *testing.T) {
 				t.Errorf("Found %d User-Agent headers, expected only 1. Headers: %v", userAgentCount, result)
 			}
 		})
+	}
+}
+
+// TestRequest_DoesNotLeakRequestDataToDefaultLogger guards against the
+// pre-existing "DEBUG: ..." hclog.Info calls in Req.Do and Request that
+// emitted request bodies and headers (including Authorization) to stderr
+// regardless of verbose mode. The test installs a recording logger via
+// hclog.SetDefault and asserts that no sentinel content from a request
+// reaches it.
+func TestRequest_DoesNotLeakRequestDataToDefaultLogger(t *testing.T) {
+	var buf bytes.Buffer
+	recorder := hclog.New(&hclog.LoggerOptions{
+		Name:   "http-test-recorder",
+		Output: &buf,
+		Level:  hclog.Trace,
+	})
+	old := hclog.SetDefault(recorder)
+	t.Cleanup(func() { hclog.SetDefault(old) })
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("POST", "http://example.test/v1/auth",
+		httpmock.NewStringResponder(200, "ok"))
+
+	const (
+		sentinelBody = "secret-payload-must-not-leak"
+		sentinelAuth = "Bearer SUPER-SECRET-TOKEN"
+	)
+
+	if _, err := Request(map[string]any{
+		"url":    "http://example.test/v1/auth",
+		"method": "POST",
+		"body":   sentinelBody,
+		"headers": map[string]any{
+			"Authorization": sentinelAuth,
+		},
+	}); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+
+	out := buf.String()
+	for _, sentinel := range []string{"DEBUG:", sentinelBody, sentinelAuth} {
+		if strings.Contains(out, sentinel) {
+			t.Errorf("default logger leaked %q.\nlogger output:\n%s", sentinel, out)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- \`Req.Do\` and \`Request\` (in \`http/client.go\`) called \`hclog.Default().Info(\"DEBUG: ...\")\` and dumped the request body + full \`Header\` map (including \`Authorization\`) to stderr **regardless of verbose mode**. Anyone running probe in production saw secrets in their logs.
- Removed those calls (and the now-unused \`hclog\` import).
- Removed the trailing \`else { hclog.Default().Info(\"DEBUG: ...\") }\` and the duplicate \`else if headersAnyMap, ok := headersInterface.(map[string]any)\` branch that came right after the \`headersInterfaceMap, ok := headersInterface.(map[string]any)\` branch — Go aliases \`map[string]any\` and \`map[string]interface{}\`, so that case was already unreachable. This keeps the if-chain readable now that the DEBUG logs no longer disambiguate them.

## Test plan
- [x] New \`TestRequest_DoesNotLeakRequestDataToDefaultLogger\` installs a recording \`hclog\` via \`hclog.SetDefault\`, fires a request with sentinel \`Authorization: Bearer SUPER-SECRET-TOKEN\` and a sentinel body, then asserts the recorder never sees those values nor any \`DEBUG:\` marker. Fails on the previous code (recorder shows the bearer token and body verbatim), passes after the fix.
- [x] \`go test -race ./...\` — all packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)