### PR TITLE
Preserve JSON array bodies in mustMarshalJSON

### DIFF
--- a/formatting.go
+++ b/formatting.go
@@ -6,24 +6,47 @@ import (
 	"strings"
 )
 
-// mustMarshalJSON attempts to unmarshal a JSON string into map[string]any.
-// If unmarshaling fails, returns a map with an error message instead of panicking.
+// mustMarshalJSON attempts to unmarshal a JSON string into either a
+// map[string]any (object input) or []any (array input). On failure it
+// returns a map[string]any with an error_message instead of panicking
+// so callers can surface the parse error.
+//
+// (The "Marshal" in the name is a legacy misnomer: this is an Unmarshal
+// helper. Renaming is intentionally left for a follow-up to keep this
+// change focused on the array-parsing fix.)
 //
 // Example:
 //
-//	result := mustMarshalJSON(`{"name": "John", "age": 30}`)
-//	// result: map[string]any{"name": "John", "age": 30}
+//	result := mustMarshalJSON(`{"name": "John"}`)
+//	// result: map[string]any{"name": "John"}
+//
+//	result := mustMarshalJSON(`[{"id": 1}, {"id": 2}]`)
+//	// result: []any{map[string]any{"id": float64(1)}, map[string]any{"id": float64(2)}}
 //
 //	result := mustMarshalJSON(`invalid json`)
 //	// result: map[string]any{"error_message": "mustMarshalJSON error: ..."}
-func mustMarshalJSON(st string) map[string]any {
-	var re map[string]any
-	if err := json.Unmarshal([]byte(st), &re); err != nil {
+func mustMarshalJSON(st string) any {
+	// Pick the target type from the first non-space byte so callers
+	// that handed us an array body don't get their data replaced by
+	// the unmarshal error from the (object-only) default branch.
+	trimmed := strings.TrimLeft(st, " \t\r\n")
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var arr []any
+		if err := json.Unmarshal([]byte(st), &arr); err != nil {
+			return map[string]any{
+				"error_message": fmt.Sprintf("mustMarshalJSON error: %s", err),
+			}
+		}
+		return arr
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(st), &obj); err != nil {
 		return map[string]any{
 			"error_message": fmt.Sprintf("mustMarshalJSON error: %s", err),
 		}
 	}
-	return re
+	return obj
 }
 
 // isJSON checks if a string appears to be JSON by examining its first and last characters.

--- a/formatting_test.go
+++ b/formatting_test.go
@@ -4,6 +4,54 @@ import (
 	"testing"
 )
 
+func TestMustMarshalJSON(t *testing.T) {
+	t.Run("object input is unmarshaled into map[string]any", func(t *testing.T) {
+		got := mustMarshalJSON(`{"name":"John","age":30}`)
+		obj, ok := got.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map[string]any, got %T (%+v)", got, got)
+		}
+		if obj["name"] != "John" {
+			t.Errorf("expected name=John, got %v", obj["name"])
+		}
+	})
+
+	t.Run("array input is unmarshaled into []any (regression: was clobbered with error_message)", func(t *testing.T) {
+		// step.go feeds any body that isJSON accepts (both `{...}` and
+		// `[...]`) into mustMarshalJSON, so when an HTTP/DB action
+		// returns a JSON array the body must round-trip as []any.
+		// Previously the array path failed Unmarshal-into-map and the
+		// caller's res.body got replaced by the error_message map.
+		got := mustMarshalJSON(`[{"id":1},{"id":2}]`)
+		arr, ok := got.([]any)
+		if !ok {
+			t.Fatalf("expected []any for array JSON input, got %T (%+v)", got, got)
+		}
+		if len(arr) != 2 {
+			t.Fatalf("expected 2 items, got %d (%+v)", len(arr), arr)
+		}
+		first, ok := arr[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected first element to be map[string]any, got %T", arr[0])
+		}
+		if id, _ := first["id"].(float64); id != 1 {
+			t.Errorf("expected first id=1, got %v", first["id"])
+		}
+	})
+
+	t.Run("invalid JSON yields an error_message map", func(t *testing.T) {
+		got := mustMarshalJSON(`not-json`)
+		obj, ok := got.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map[string]any with error_message, got %T (%+v)", got, got)
+		}
+		msg, ok := obj["error_message"].(string)
+		if !ok || msg == "" {
+			t.Errorf("expected non-empty error_message, got %v", obj)
+		}
+	})
+}
+
 func TestIsJSON(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- \`step.go\` feeds any HTTP/DB response body that \`isJSON\` accepts into \`mustMarshalJSON\` before stashing it on \`res.body\`. \`isJSON\` returns true for both \`{...}\` and \`[...]\`, but \`mustMarshalJSON\` only attempted to Unmarshal into \`map[string]any\` — so every JSON-array response had its body silently replaced with \`{\"error_message\": \"json: cannot unmarshal array into Go value of type map[string]interface {}\"}\`. Any \`test\`/\`echo\` expression that read \`res.body\` (e.g. \`res.body[0].id\`) or that compared the body to expected JSON would then fail or read the wrong shape.
- Switch the return type of \`mustMarshalJSON\` to \`any\` and pick the target between \`map[string]any\` and \`[]any\` from the first non-space byte. The \`error_message\` map is still returned on parse failure, so the contract for invalid input is preserved.
- The \`mustMarshalJSON\` name is a legacy misnomer (it Unmarshals); a follow-up rename is intentionally out of scope here so the diff is just the array-handling fix.

## Test plan
- [x] New \`TestMustMarshalJSON\` covers object / array (regression) / invalid-JSON paths. Without the fix the array case fails with \`expected []any for array JSON input, got map[string]interface {}\` carrying the unmarshal error; after the fix all three subtests pass.
- [x] \`go test -race ./...\` — all packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)