### PR TITLE
Collapse isSafeEnvKey into a single blocklist

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -257,48 +256,35 @@ func (e *Expr) createSafeEnvironment(env any) any {
 	return safeEnv
 }
 
-// Security: Check if environment key is safe to expose
+// isSafeEnvKey reports whether the given environment variable name is
+// safe to expose to expression evaluation. probe uses a blocklist
+// model: any key whose upper-cased form *contains* one of the patterns
+// below is rejected, and every other key is allowed. The substring
+// match is intentional so compound names like "DB_PASSWORD" or
+// "MY_API_KEY" still get rejected, at the cost of also rejecting
+// unrelated keys that happen to embed one of these substrings (e.g.
+// anything containing "KEY"). That conservative bias is deliberate.
+//
+// Historical note: this used to layer prefix / safeKeys / testEnvVars /
+// fallback whitelists on top of the blocklist, but every one of those
+// branches collapsed back to "anything that survived the blocklist is
+// allowed" — none of them actually narrowed what was reachable. They
+// were removed so the contract here matches the code.
 func (e *Expr) isSafeEnvKey(key string) bool {
-	// Security: Block dangerous environment variables
-	dangerousKeys := []string{
+	upperKey := strings.ToUpper(key)
+	blocklist := []string{
+		// Shell and host metadata
 		"PATH", "HOME", "USER", "USERNAME", "SHELL", "PWD",
+		// Credential-bearing names
 		"SECRET", "KEY", "TOKEN", "PASSWORD", "CREDENTIAL",
 		"API_KEY", "PRIVATE", "CERT", "SSH",
 	}
-
-	upperKey := strings.ToUpper(key)
-	for _, dangerous := range dangerousKeys {
-		if strings.Contains(upperKey, dangerous) {
+	for _, pattern := range blocklist {
+		if strings.Contains(upperKey, pattern) {
 			return false
 		}
 	}
-
-	// Allow only result data and safe variables
-	allowedPrefixes := []string{"res.", "result.", "data.", "response."}
-	for _, prefix := range allowedPrefixes {
-		if strings.HasPrefix(strings.ToLower(key), prefix) {
-			return true
-		}
-	}
-
-	// Allow basic result variables
-	safeKeys := []string{"res", "result", "data", "response", "body", "status", "headers", "host", "name", "service", "authorization", "url", "repeat_index"}
-	if slices.Contains(safeKeys, strings.ToLower(key)) {
-		return true
-	}
-
-	// Allow test environment variables but block real secrets
-	testEnvVars := []string{"TOKEN", "HOST", "URL", "PORT"}
-	if slices.Contains(testEnvVars, upperKey) {
-		return true
-	}
-
-	// Allow environment variables that are commonly used in tests/configs (but not secrets)
-	if !strings.Contains(upperKey, "SECRET") && !strings.Contains(upperKey, "API_KEY") && !strings.Contains(upperKey, "PRIVATE") && !strings.Contains(upperKey, "PASSWORD") {
-		return true
-	}
-
-	return false
+	return true
 }
 
 // Security: Sanitize values to prevent injection

--- a/expr_test.go
+++ b/expr_test.go
@@ -584,6 +584,50 @@ func TestEvalTemplateMapTypePreservation(t *testing.T) {
 	}
 }
 
+// TestIsSafeEnvKey pins the blocklist contract of isSafeEnvKey so the
+// upcoming simplification (collapsing the redundant prefix / safeKeys /
+// testEnvVars / fallback branches into a single Contains-based blocklist)
+// can't silently change which environment keys reach expr templates.
+func TestIsSafeEnvKey(t *testing.T) {
+	expr := &Expr{}
+
+	blocked := []string{
+		// Shell / host metadata
+		"PATH", "HOME", "USER", "USERNAME", "SHELL", "PWD",
+		// Credentials and secret-bearing names
+		"SECRET", "SECRET_KEY", "DB_PASSWORD", "API_KEY",
+		"AWS_SECRET_ACCESS_KEY", "MY_CREDENTIAL",
+		"PRIVATE_KEY", "SSH_AUTH_SOCK", "TLS_CERT",
+		// Contains-match catches any substring hit
+		"USER_HOME", "RUNTIME_PATH", "HAS_TOKEN",
+	}
+	for _, key := range blocked {
+		t.Run("blocked/"+key, func(t *testing.T) {
+			if expr.isSafeEnvKey(key) {
+				t.Errorf("isSafeEnvKey(%q) = true, want false", key)
+			}
+		})
+	}
+
+	allowed := []string{
+		// Expression-result identifiers expected to be reachable
+		"res", "result", "data", "response", "body", "status",
+		"headers", "host", "name", "service", "authorization",
+		"url", "repeat_index",
+		// Common deployment metadata that doesn't carry a secret-marker
+		"HOST", "URL", "PORT",
+		// Arbitrary user-defined names without a blocklisted substring
+		"my_var", "FEATURE_FLAG", "ENVIRONMENT", "REGION",
+	}
+	for _, key := range allowed {
+		t.Run("allowed/"+key, func(t *testing.T) {
+			if !expr.isSafeEnvKey(key) {
+				t.Errorf("isSafeEnvKey(%q) = false, want true", key)
+			}
+		})
+	}
+}
+
 func TestSafeEnvironment(t *testing.T) {
 	expr := &Expr{}
 


### PR DESCRIPTION
## Summary
\`isSafeEnvKey\` was commented as a whitelist but actually stacked four allow-branches on top of a blocklist, every one of which was dead or already covered:

| Branch | Why it was effectively a no-op |
|---|---|
| \`allowedPrefixes\` (\`res.\`, \`result.\`, \`data.\`, \`response.\`) | Only reachable after the blocklist had already let the key through, so it never changed an outcome. |
| \`safeKeys\` exact-match list | A strict subset of keys that already survived the blocklist. |
| \`testEnvVars\` (includes \`TOKEN\`) | \`TOKEN\` is in the blocklist (\`Contains(\"TOKEN\")\`); the branch was unreachable. |
| Final fallback (\`!Contains(SECRET/API_KEY/PRIVATE/PASSWORD)\`) | All four substrings were already rejected by the blocklist, so this branch effectively returned \`true\` unconditionally. |

Drop those branches and document the function as a blocklist so the contract matches the code. **Behavior is unchanged**: a key is rejected iff its upper-cased form contains one of \`PATH / HOME / USER / USERNAME / SHELL / PWD / SECRET / KEY / TOKEN / PASSWORD / CREDENTIAL / API_KEY / PRIVATE / CERT / SSH\`, otherwise allowed.

Also drop the now-unused \`slices\` import.

## Test plan
- [x] Added \`TestIsSafeEnvKey\` as a characterization test pinning the blocklist contract (blocked: \`PATH\`, \`SECRET_KEY\`, \`DB_PASSWORD\`, \`AWS_SECRET_ACCESS_KEY\`, \`HAS_TOKEN\`, …; allowed: \`res\`, \`host\`, \`url\`, \`FEATURE_FLAG\`, \`my_var\`, …). Passes against the original code and against the simplified code — i.e. the cleanup is behavior-preserving.
- [x] The pre-existing \`TestSafeEnvironment\` (block \`SECRET_KEY\` / \`PASSWORD\` / \`PATH\`, allow \`res\` / \`result\` / \`data\` / \`response\` / \`HOST\` / \`URL\`) still passes unchanged.
- [x] \`go test -race ./...\` — all packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)